### PR TITLE
Frequency response calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
             - libfftw3-dev
             - qt5-default
             - libusb-1.0-0-dev
+            - libeigen3-dev
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
     - os: osx

--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -130,6 +130,7 @@ unix:!android:!macx{
     CONFIG += link_pkgconfig
     PKGCONFIG += libusb-1.0  ##make sure you have the libusb-1.0-0-dev package!
     PKGCONFIG += fftw3       ##make sure you have the libfftw3-dev package!
+    PKGCONFIG += eigen3      ##make sure you have the libeigen3-dev package!
     contains(QT_ARCH, arm) {
             message("Building for Raspberry Pi")
             #libdfuprog include

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -61,6 +61,24 @@ void isoBuffer::insertIntoBuffer(short item)
     if (m_asyncDftActive)
         async_dft->addSample(item);
 
+    /* Fill-in freqResp buffer */
+    if(m_freqRespActive)
+    {
+        if (freqResp_count >= freqResp_samples)
+        {
+            /* Shift freqResp buffer once by removing first element and adding an element to the end */
+            freqResp_buffer.pop_front();
+            freqResp_buffer.push_back(item);
+            freqResp_count = freqResp_samples;
+        }
+        else
+        {
+            freqResp_buffer.push_back(item);
+        }
+        /* Update number of freqResp samples */
+        freqResp_count++;
+    }
+
     checkTriggered();
 }
 
@@ -188,6 +206,12 @@ void isoBuffer::enableDftWrite(bool enable)
     }
 
     m_asyncDftActive = enable;
+}
+
+void isoBuffer::enableFreqResp(bool enable, double freqValue)
+{
+    m_freqRespActive = enable;
+    freqResp_samples = uint32_t(m_samplesPerSecond/freqValue);
 }
 
 void isoBuffer::outputSampleToFile(double averageSample)

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -58,6 +58,7 @@ public:
 	void gainBuffer(int gain_log);
 
 	void enableDftWrite(bool enable);
+	void enableFreqResp(bool enable, double freqValue);
 
 // Advanced buffer operations
 private:
@@ -107,6 +108,10 @@ public:
 	uint32_t m_insertedCount = 0;
 	uint32_t m_bufferLen;
 
+	std::list<short> freqResp_buffer;
+	uint32_t freqResp_count = 0;
+	uint32_t freqResp_samples = 0;
+
 // Conversion And Sampling
 	double m_voltage_ref = 1.65;
 	double m_frontendGain = (R4 / (R3 + R4));
@@ -135,6 +140,7 @@ private:
     uint32_t m_lastTriggerDetlaT = 0;
 
 	bool m_asyncDftActive = false;
+	bool m_freqRespActive = false;
 
 	isoDriver* m_virtualParent;
 

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -1855,3 +1855,8 @@ void isoDriver::setFreqRespType(int freqRespType)
     m_freqRespType = freqRespType;
 }
 
+void isoDriver::restartFreqResp()
+{
+    m_freqRespFlag = true;
+}
+

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -950,8 +950,8 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
 
                     // Select new frequency
                     double freqValue = freqValue_CH1->value() + m_freqRespStep;
-                    if(freqValue >= m_freqRespMax || freqValue < m_freqRespMin || m_freqRespFreq.size() == 0)
-                        freqValue = m_freqRespMin + m_freqRespStep;
+                    if(freqValue > m_freqRespMax || freqValue < m_freqRespMin || m_freqRespFreq.size() == 0)
+                        freqValue = m_freqRespMin;
                     freqValue_CH1->setValue(freqValue);
 
                     // Reset iterators

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -11,6 +11,7 @@
 #include "siprint.h"
 #include "i2cdecoder.h"
 #include "uartstyledecoder.h"
+#include "espospinbox.h"
 
 class isoBuffer;
 class isoBuffer_file;
@@ -90,6 +91,8 @@ public:
     bool fileModeEnabled = false;
     double daq_maxWindowSize;
     bool spectrum = false;
+    bool freqResp = false;
+    espoSpinBox *freqValue_CH1 = NULL;
 private:
     //Those bloody bools that just Enable/Disable a single property
     bool paused_CH1 = false;
@@ -191,6 +194,15 @@ private:
     //Spectrum
     double m_spectrumMinX = 0;
     double m_spectrumMaxX = 187500;
+    //Frequency response
+    QVector<double> m_freqRespFreq;
+    QVector<double> m_freqRespGain;
+    QVector<double> m_freqRespPhase;
+    double m_freqRespMin = 0;
+    double m_freqRespMax = 62500;
+    int m_freqRespStep = 100;
+    int m_freqRespType = 0;
+    bool m_freqRespFlag = false;
 
 signals:
     void setGain(double newGain);
@@ -290,6 +302,10 @@ public slots:
     void setHexDisplay_CH2(bool enabled);
     void setMinSpectrum(int minSpectrum);
     void setMaxSpectrum(int maxSpectrum);
+    void setMinFreqResp(int minFreqResp);
+    void setMaxFreqResp(int maxFreqResp);
+    void setFreqRespStep(int stepFreqResp);
+    void setFreqRespType(int typeFreqResp);
 };
 
 #endif // ISODRIVER_H

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -198,8 +198,8 @@ private:
     QVector<double> m_freqRespFreq;
     QVector<double> m_freqRespGain;
     QVector<double> m_freqRespPhase;
-    double m_freqRespMin = 0;
-    double m_freqRespMax = 62500;
+    double m_freqRespMin = 100;
+    double m_freqRespMax = 32500;
     int m_freqRespStep = 100;
     int m_freqRespType = 0;
     bool m_freqRespFlag = false;

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -306,6 +306,7 @@ public slots:
     void setMaxFreqResp(int maxFreqResp);
     void setFreqRespStep(int stepFreqResp);
     void setFreqRespType(int typeFreqResp);
+    void restartFreqResp();
 };
 
 #endif // ISODRIVER_H

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -53,6 +53,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->controller_iso->setDriver(new _PLATFORM_DEPENDENT_USB_OBJECT());
     ui->controller_iso->setAxes(ui->scopeAxes);
 
+    ui->controller_iso->freqValue_CH1 = ui->frequencyValue_CH1;
+    connect(ui->frequencyValue_CH1, SIGNAL(valueChanged(double)), this, SLOT(display(double)));
+
     ui->timeBaseSlider->setMaximum(10*log10(MAX_WINDOW_SIZE));
 
     //ui->controller_iso->driver->setBufferPtr(ui->bufferDisplay);
@@ -244,11 +247,13 @@ MainWindow::MainWindow(QWidget *parent) :
 #ifndef PLATFORM_ANDROID
     connect(ui->offsetSpinBox_CH1, SIGNAL(valueChanged(double)), ui->controller_iso, SLOT(offsetChanged_CH1(double)));
     connect(ui->offsetSpinBox_CH2, SIGNAL(valueChanged(double)), ui->controller_iso, SLOT(offsetChanged_CH2(double)));
+
     connect(ui->attenuationComboBox_CH1, SIGNAL(currentIndexChanged(int)), ui->controller_iso, SLOT(attenuationChanged_CH1(int)));
     connect(ui->attenuationComboBox_CH2, SIGNAL(currentIndexChanged(int)), ui->controller_iso, SLOT(attenuationChanged_CH2(int)));
 #endif
     connect(ui->controller_iso, &isoDriver::enableCursorGroup, this, &MainWindow::cursorGroupEnabled);
 
+    // Frequency spectrum
     spectrumMinXSpinbox = new QSpinBox();
     spectrumMaxXSpinbox = new QSpinBox();
     spectrumLayoutWidget = new QWidget();
@@ -280,6 +285,64 @@ MainWindow::MainWindow(QWidget *parent) :
 
     ui->verticalLayout->addWidget(spectrumLayoutWidget);
     spectrumLayoutWidget->setVisible(false);
+
+    // Frequency response
+    freqRespLayout1Widget = new QWidget();
+    freqRespLayout2Widget = new QWidget();
+    freqRespMinXSpinbox   = new QSpinBox();
+    freqRespMaxXSpinbox   = new QSpinBox();
+    freqRespStepSpinbox   = new QSpinBox();
+    freqRespTypeComboBox  = new QComboBox();
+    QHBoxLayout* freqRespLayout1 = new QHBoxLayout(freqRespLayout1Widget);
+    QHBoxLayout* freqRespLayout2 = new QHBoxLayout(freqRespLayout2Widget);
+    QLabel* freqRespMinFreqLabel = new QLabel("Min Frequency (Hz)");
+    QLabel* freqRespMaxFreqLabel = new QLabel("Max Frequency (Hz)");
+    QLabel* freqRespStepLabel = new QLabel("Step (Hz)");
+    QLabel* freqRespTypeLabel = new QLabel("Response");
+
+    freqRespLayout1Widget->setLayout(freqRespLayout1);
+    freqRespMinXSpinbox->setMinimum(100);
+    freqRespMinXSpinbox->setMaximum(62500);
+    freqRespMaxXSpinbox->setMinimum(100);
+    freqRespMaxXSpinbox->setMaximum(62500);
+    freqRespMaxXSpinbox->setValue(32500);
+
+    freqRespLayout1->addItem(spacer);
+    freqRespLayout1->addWidget(freqRespMinFreqLabel);
+    freqRespLayout1->addWidget(freqRespMinXSpinbox);
+    freqRespLayout1->addItem(spacer);
+    freqRespLayout1->addWidget(freqRespMaxFreqLabel);
+    freqRespLayout1->addWidget(freqRespMaxXSpinbox);
+    freqRespLayout1->addItem(spacer);
+
+    freqRespLayout2Widget->setLayout(freqRespLayout2);
+    freqRespStepSpinbox->setMinimum(10);
+    freqRespStepSpinbox->setMaximum(10000);
+    freqRespStepSpinbox->setValue(100);
+    freqRespTypeComboBox->addItem("Gain");
+    freqRespTypeComboBox->addItem("Phase");
+    freqRespTypeComboBox->setCurrentIndex(0);
+
+    freqRespLayout2->addItem(spacer);
+    freqRespLayout2->addWidget(freqRespStepLabel);
+    freqRespLayout2->addWidget(freqRespStepSpinbox);
+    freqRespLayout2->addItem(spacer);
+    freqRespLayout2->addWidget(freqRespTypeLabel);
+    freqRespLayout2->addWidget(freqRespTypeComboBox);
+    freqRespLayout2->addItem(spacer);
+
+    connect(freqRespMinXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMinFreqResp);
+    connect(freqRespMaxXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMaxFreqResp);
+    connect(freqRespStepSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), ui->controller_iso, &isoDriver::setFreqRespStep);
+    connect(freqRespTypeComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), ui->controller_iso, &isoDriver::setFreqRespType);
+
+    connect(freqRespMinXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), freqRespMaxXSpinbox, &QSpinBox::setMinimum);
+    connect(freqRespMaxXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), freqRespMinXSpinbox, &QSpinBox::setMaximum);
+
+    ui->verticalLayout->addWidget(freqRespLayout1Widget);
+    ui->verticalLayout->addWidget(freqRespLayout2Widget);
+    freqRespLayout1Widget->setVisible(false);
+    freqRespLayout2Widget->setVisible(false);
 }
 
 MainWindow::~MainWindow()
@@ -2567,11 +2630,33 @@ void MainWindow::on_actionFrequency_Spectrum_triggered(bool checked)
 {
     ui->controller_iso->spectrum = checked;
     spectrumLayoutWidget->setVisible(checked);
+    if(checked)
+    {
+        ui->controller_iso->freqResp = false;
+        freqRespLayout1Widget->setVisible(false);
+        freqRespLayout2Widget->setVisible(false);
+        ui->actionFrequency_Response->setChecked(false);
+    }
 
     if (checked == true)
         MAX_WINDOW_SIZE = 1<<17;
     else
         MAX_WINDOW_SIZE = 10;
+}
+
+void MainWindow::on_actionFrequency_Response_triggered(bool checked)
+{
+    ui->controller_iso->freqResp = checked;
+    freqRespLayout1Widget->setVisible(checked);
+    freqRespLayout2Widget->setVisible(checked);
+    if(checked)
+    {
+        ui->controller_iso->spectrum = false;
+        spectrumLayoutWidget->setVisible(false);
+        ui->actionFrequency_Spectrum->setChecked(false);
+        ui->scopeGroup_CH2->setChecked(true);
+    }
+    ui->scopeGroup_CH2->setDisabled(checked);
 }
 
 std::vector<uint8_t> MainWindow::uartEncode(const QString& text, UartParity parity)

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -303,6 +303,7 @@ MainWindow::MainWindow(QWidget *parent) :
     freqRespLayout1Widget->setLayout(freqRespLayout1);
     freqRespMinXSpinbox->setMinimum(100);
     freqRespMinXSpinbox->setMaximum(62500);
+    freqRespMinXSpinbox->setValue(100);
     freqRespMaxXSpinbox->setMinimum(100);
     freqRespMaxXSpinbox->setMaximum(62500);
     freqRespMaxXSpinbox->setValue(32500);

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -338,6 +338,7 @@ MainWindow::MainWindow(QWidget *parent) :
     freqRespLayout2->addItem(spacer);
     freqRespLayout2->addWidget(freqRespRestartButton);
     freqRespLayout2->addItem(spacer);
+    freqRespLayout2->addItem(spacer);
 
     connect(freqRespMinXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMinFreqResp);
     connect(freqRespMaxXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMaxFreqResp);
@@ -2644,6 +2645,11 @@ void MainWindow::on_actionFrequency_Spectrum_triggered(bool checked)
 {
     ui->controller_iso->spectrum = checked;
     spectrumLayoutWidget->setVisible(checked);
+    if(ui->controller_iso->freqResp)
+    {
+        ui->scopeGroup_CH1->setCheckable(true);
+        ui->scopeGroup_CH2->setCheckable(true);
+    }
     if(checked)
     {
         ui->controller_iso->freqResp = false;
@@ -2669,8 +2675,11 @@ void MainWindow::on_actionFrequency_Response_triggered(bool checked)
         ui->controller_iso->spectrum = false;
         spectrumLayoutWidget->setVisible(false);
         ui->actionFrequency_Spectrum->setChecked(false);
+        ui->scopeGroup_CH1->setChecked(true);
         ui->scopeGroup_CH2->setChecked(true);
     }
+    ui->scopeGroup_CH1->setCheckable(!checked);
+    ui->scopeGroup_CH2->setCheckable(!checked);
     ui->scopeGroup_CH2->setDisabled(checked);
 }
 

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -289,21 +289,23 @@ MainWindow::MainWindow(QWidget *parent) :
     // Frequency response
     freqRespLayout1Widget = new QWidget();
     freqRespLayout2Widget = new QWidget();
-    freqRespMinXSpinbox   = new QSpinBox();
-    freqRespMaxXSpinbox   = new QSpinBox();
-    freqRespStepSpinbox   = new QSpinBox();
+    freqRespMinXSpinbox   = new espoSpinBox();
+    freqRespMaxXSpinbox   = new espoSpinBox();
+    freqRespStepSpinbox   = new espoSpinBox();
     freqRespTypeComboBox  = new QComboBox();
     QHBoxLayout* freqRespLayout1 = new QHBoxLayout(freqRespLayout1Widget);
     QHBoxLayout* freqRespLayout2 = new QHBoxLayout(freqRespLayout2Widget);
-    QLabel* freqRespMinFreqLabel = new QLabel("Min Frequency (Hz)");
-    QLabel* freqRespMaxFreqLabel = new QLabel("Max Frequency (Hz)");
-    QLabel* freqRespStepLabel = new QLabel("Step (Hz)");
+    QLabel* freqRespMinFreqLabel = new QLabel("Min Frequency");
+    QLabel* freqRespMaxFreqLabel = new QLabel("Max Frequency");
+    QLabel* freqRespStepLabel = new QLabel("Step");
     QLabel* freqRespTypeLabel = new QLabel("Response");
 
     freqRespLayout1Widget->setLayout(freqRespLayout1);
+    freqRespMinXSpinbox->setSuffix(QString::fromUtf8("Hz"));
     freqRespMinXSpinbox->setMinimum(100);
     freqRespMinXSpinbox->setMaximum(62500);
     freqRespMinXSpinbox->setValue(100);
+    freqRespMaxXSpinbox->setSuffix(QString::fromUtf8("Hz"));
     freqRespMaxXSpinbox->setMinimum(100);
     freqRespMaxXSpinbox->setMaximum(62500);
     freqRespMaxXSpinbox->setValue(32500);
@@ -317,6 +319,7 @@ MainWindow::MainWindow(QWidget *parent) :
     freqRespLayout1->addItem(spacer);
 
     freqRespLayout2Widget->setLayout(freqRespLayout2);
+    freqRespStepSpinbox->setSuffix(QString::fromUtf8("Hz"));
     freqRespStepSpinbox->setMinimum(10);
     freqRespStepSpinbox->setMaximum(10000);
     freqRespStepSpinbox->setValue(100);
@@ -332,13 +335,17 @@ MainWindow::MainWindow(QWidget *parent) :
     freqRespLayout2->addWidget(freqRespTypeComboBox);
     freqRespLayout2->addItem(spacer);
 
-    connect(freqRespMinXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMinFreqResp);
-    connect(freqRespMaxXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMaxFreqResp);
-    connect(freqRespStepSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), ui->controller_iso, &isoDriver::setFreqRespStep);
+    connect(freqRespMinXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMinFreqResp);
+    connect(freqRespMaxXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMaxFreqResp);
+    connect(freqRespStepSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), ui->controller_iso, &isoDriver::setFreqRespStep);
     connect(freqRespTypeComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), ui->controller_iso, &isoDriver::setFreqRespType);
 
-    connect(freqRespMinXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), freqRespMaxXSpinbox, &QSpinBox::setMinimum);
-    connect(freqRespMaxXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), freqRespMinXSpinbox, &QSpinBox::setMaximum);
+    connect(freqRespMinXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), freqRespMaxXSpinbox, &espoSpinBox::setMinimum);
+    connect(freqRespMaxXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), freqRespMinXSpinbox, &espoSpinBox::setMaximum);
+
+    connect(freqRespMinXSpinbox, SIGNAL(valueChanged(double)), freqRespMinXSpinbox, SLOT(changeStepping(double)));
+    connect(freqRespMaxXSpinbox, SIGNAL(valueChanged(double)), freqRespMaxXSpinbox, SLOT(changeStepping(double)));
+    connect(freqRespStepSpinbox, SIGNAL(valueChanged(double)), freqRespStepSpinbox, SLOT(changeStepping(double)));
 
     ui->verticalLayout->addWidget(freqRespLayout1Widget);
     ui->verticalLayout->addWidget(freqRespLayout2Widget);

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -2638,6 +2638,7 @@ void MainWindow::on_actionFrequency_Spectrum_triggered(bool checked)
         freqRespLayout2Widget->setVisible(false);
         ui->actionFrequency_Response->setChecked(false);
     }
+    ui->scopeGroup_CH2->setDisabled(false);
 
     if (checked == true)
         MAX_WINDOW_SIZE = 1<<17;

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -293,6 +293,7 @@ MainWindow::MainWindow(QWidget *parent) :
     freqRespMaxXSpinbox   = new espoSpinBox();
     freqRespStepSpinbox   = new espoSpinBox();
     freqRespTypeComboBox  = new QComboBox();
+    freqRespRestartButton = new QPushButton("Restart");
     QHBoxLayout* freqRespLayout1 = new QHBoxLayout(freqRespLayout1Widget);
     QHBoxLayout* freqRespLayout2 = new QHBoxLayout(freqRespLayout2Widget);
     QLabel* freqRespMinFreqLabel = new QLabel("Min Frequency");
@@ -328,17 +329,21 @@ MainWindow::MainWindow(QWidget *parent) :
     freqRespTypeComboBox->setCurrentIndex(0);
 
     freqRespLayout2->addItem(spacer);
+    freqRespLayout2->addItem(spacer);
     freqRespLayout2->addWidget(freqRespStepLabel);
     freqRespLayout2->addWidget(freqRespStepSpinbox);
     freqRespLayout2->addItem(spacer);
     freqRespLayout2->addWidget(freqRespTypeLabel);
     freqRespLayout2->addWidget(freqRespTypeComboBox);
     freqRespLayout2->addItem(spacer);
+    freqRespLayout2->addWidget(freqRespRestartButton);
+    freqRespLayout2->addItem(spacer);
 
     connect(freqRespMinXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMinFreqResp);
     connect(freqRespMaxXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMaxFreqResp);
     connect(freqRespStepSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), ui->controller_iso, &isoDriver::setFreqRespStep);
     connect(freqRespTypeComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), ui->controller_iso, &isoDriver::setFreqRespType);
+    connect(freqRespRestartButton, &QPushButton::clicked, ui->controller_iso, &isoDriver::restartFreqResp);
 
     connect(freqRespMinXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), freqRespMaxXSpinbox, &espoSpinBox::setMinimum);
     connect(freqRespMaxXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), freqRespMinXSpinbox, &espoSpinBox::setMaximum);
@@ -346,6 +351,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(freqRespMinXSpinbox, SIGNAL(valueChanged(double)), freqRespMinXSpinbox, SLOT(changeStepping(double)));
     connect(freqRespMaxXSpinbox, SIGNAL(valueChanged(double)), freqRespMaxXSpinbox, SLOT(changeStepping(double)));
     connect(freqRespStepSpinbox, SIGNAL(valueChanged(double)), freqRespStepSpinbox, SLOT(changeStepping(double)));
+
 
     ui->verticalLayout->addWidget(freqRespLayout1Widget);
     ui->verticalLayout->addWidget(freqRespLayout2Widget);

--- a/Desktop_Interface/mainwindow.h
+++ b/Desktop_Interface/mainwindow.h
@@ -227,6 +227,7 @@ private slots:
 
     void on_actionShow_Debug_Console_triggered(bool checked);
     void on_actionFrequency_Spectrum_triggered(bool checked);
+    void on_actionFrequency_Response_triggered(bool checked);
 
     void on_serialEncodingCheck_CH1_toggled(bool checked);
     void on_txuart_textChanged();
@@ -303,9 +304,18 @@ private:
     QShortcut *shortcut_Debug;
     QShortcut *shortcut_Esc;
 
+    // Frequency spectrum
     QWidget* spectrumLayoutWidget = nullptr;
     QSpinBox* spectrumMinXSpinbox = nullptr;
     QSpinBox* spectrumMaxXSpinbox = nullptr;
+
+    // Frequency response
+    QWidget* freqRespLayout1Widget = nullptr;
+    QWidget* freqRespLayout2Widget = nullptr;
+    QSpinBox* freqRespMinXSpinbox = nullptr;
+    QSpinBox* freqRespMaxXSpinbox = nullptr;
+    QSpinBox* freqRespStepSpinbox = nullptr;
+    QComboBox* freqRespTypeComboBox = nullptr;
 
     //Duct Tape
     bool dt_AlreadyAskedAboutCalibration = false;

--- a/Desktop_Interface/mainwindow.h
+++ b/Desktop_Interface/mainwindow.h
@@ -316,6 +316,7 @@ private:
     espoSpinBox* freqRespMaxXSpinbox = nullptr;
     espoSpinBox* freqRespStepSpinbox = nullptr;
     QComboBox* freqRespTypeComboBox = nullptr;
+    QPushButton *freqRespRestartButton = nullptr;
 
     //Duct Tape
     bool dt_AlreadyAskedAboutCalibration = false;

--- a/Desktop_Interface/mainwindow.h
+++ b/Desktop_Interface/mainwindow.h
@@ -312,9 +312,9 @@ private:
     // Frequency response
     QWidget* freqRespLayout1Widget = nullptr;
     QWidget* freqRespLayout2Widget = nullptr;
-    QSpinBox* freqRespMinXSpinbox = nullptr;
-    QSpinBox* freqRespMaxXSpinbox = nullptr;
-    QSpinBox* freqRespStepSpinbox = nullptr;
+    espoSpinBox* freqRespMinXSpinbox = nullptr;
+    espoSpinBox* freqRespMaxXSpinbox = nullptr;
+    espoSpinBox* freqRespStepSpinbox = nullptr;
     QComboBox* freqRespTypeComboBox = nullptr;
 
     //Duct Tape

--- a/Desktop_Interface/ui_files_desktop/mainwindow.ui
+++ b/Desktop_Interface/ui_files_desktop/mainwindow.ui
@@ -1699,6 +1699,7 @@
     <addaction name="separator"/>
     <addaction name="actionHide_Widget_Oscilloscope"/>
     <addaction name="actionFrequency_Spectrum"/>
+    <addaction name="actionFrequency_Response"/>
    </widget>
    <widget class="QMenu" name="menuMultimeter_2">
     <property name="title">
@@ -2747,6 +2748,14 @@
    </property>
    <property name="text">
     <string>Frequency Spectrum</string>
+   </property>
+  </action>
+  <action name="actionFrequency_Response">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Frequency Response</string>
    </property>
   </action>
  </widget>

--- a/labrador_bootstrap_pi
+++ b/labrador_bootstrap_pi
@@ -13,11 +13,13 @@ dpkg -s libusb-1.0-0-dev
 LIBUSB_NOT_INSTALLED=$?
 dpkg -s libfftw3-dev
 FFTW_NOT_INSTALLED=$?
+dpkg -s libeigen3-dev
+EIGEN3_NOT_INSTALLED=$?
 
 # We don't want to bail if one of the first 4 lines returns error.  That's what they're meant to do!
 set -e
 
-if [ $QTBASE_NOT_INSTALLED != 0 ] || [ $QTCHOOSER_NOT_INSTALLED != 0 ] || [ $QMAKE_NOT_INSTALLED != 0 ] || [ $QTDEV_NOT_INSTALLED != 0 ] || [ $LIBUSB_NOT_INSTALLED != 0 ] || [ $FFTW_NOT_INSTALLED != 0 ]; then
+if [ $QTBASE_NOT_INSTALLED != 0 ] || [ $QTCHOOSER_NOT_INSTALLED != 0 ] || [ $QMAKE_NOT_INSTALLED != 0 ] || [ $QTDEV_NOT_INSTALLED != 0 ] || [ $LIBUSB_NOT_INSTALLED != 0 ] || [ $FFTW_NOT_INSTALLED != 0 ] || [ $EIGEN3_NOT_INSTALLED != 0 ]; then
     sudo apt-get update
     sudo apt-get install -y qtbase5-dev
     sudo apt-get install -y qtchooser
@@ -25,6 +27,7 @@ if [ $QTBASE_NOT_INSTALLED != 0 ] || [ $QTCHOOSER_NOT_INSTALLED != 0 ] || [ $QMA
     sudo apt-get install -y qtbase5-dev-tools
     sudo apt-get install -y libusb-1.0-0-dev
     sudo apt-get install -y libfftw3-dev
+    sudo apt-get install -y libeigen3-dev
 else
     echo "Prerequesites are already installed.  Skipping step."
 fi


### PR DESCRIPTION
This PR will bring **frequency response calculation** to espotek's oscilloscope functionality.
Interface wise, it will be located under the oscilloscope tab, next to _Frequency Spectrum_.

![freqResp_interface](https://github.com/user-attachments/assets/8fae69b3-c102-4f61-ac84-595f9e624ea7)

Operation wise, a frequency response calculation requires
1. input source to excite the circuit-under-test (CUT) with sinusoidal waveform of varying frequencies, and
2. two output measurements for capturing the excitation and response wave-forms

To this end, Signal Gen CH1 will be used for 1 and Oscilloscope CH1/CH2 will be used for 2.

Here is an example circuit-under-test (CUT) for measuring the frequency response of an RC circuit.

![freqResp_CUT](https://github.com/user-attachments/assets/77e8038c-7e1b-4006-b35e-cdbc9cbc784d)

### Frequency response calculation steps
1. generate a sinusoidal frequency tone on Signal Gen CH1
2. capture 1 cycle of input and output wave-forms
3. using least squares regression, fit a sinusoidal to captured wave-forms
4. calculate gain(dB) and phase response (degree)
5. plot frequency response (gain or phase)
6. update next frequency tone on Signal Gen CH1 and start all over again

![freqResp_output](https://github.com/user-attachments/assets/0e4b1049-9f2b-437e-9a4e-c642b80e3517)

**Note**:
Frequency response calculation has been tested on Linux and RPI5 platforms.