### PR TITLE
Fix various string formatting warnings

### DIFF
--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cinttypes>
 #include <iostream>
 
 #include "isodriver.h"
@@ -67,7 +68,7 @@ void isoBuffer::insertIntoBuffer(short item)
 short isoBuffer::bufferAt(uint32_t idx) const
 {
     if (idx > m_insertedCount)
-        qFatal("isoBuffer::bufferAt: invalid query, idx = %lu, m_insertedCount = %lu", idx, m_insertedCount);
+        qFatal("isoBuffer::bufferAt: invalid query, idx = %" PRIu32 ", m_insertedCount = %" PRIu32, idx, m_insertedCount);
 
     return m_buffer[(m_back-1) + m_bufferLen - idx];
 }

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -1271,8 +1271,7 @@ void isoDriver::slowTimerTick(){
             siprint triggerFreqSiprint("Hz", triggerFrequency);
             siprint periodSiprint("s", 1. / triggerFrequency);
 
-            QString cursorString;
-            cursorString.sprintf(" Trigger ΔT = %s, f = %s ", periodSiprint.printVal(), triggerFreqSiprint.printVal());
+            QString cursorString = QString::asprintf(" Trigger ΔT = %s, f = %s ", periodSiprint.printVal(), triggerFreqSiprint.printVal());
             triggerFrequencyLabel->setText(cursorString);
         }
         qDebug() << triggerFrequency << "Hz";
@@ -1404,7 +1403,7 @@ void isoDriver::loadFileBuffer(QFile *fileToLoad){
         tempList.clear();
     }
 
-    qDebug("There are %d elements!", numel);
+    qDebug() << "There are" << numel << "elements!";
 
     //Prompt user for start and end times
     double defaultSampleRate = 375000;

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -373,12 +373,10 @@ void MainWindow::initialisePlot()
 }
 
 void MainWindow::labelPsu(){
-    char tempString[4];
     int tempInt = ui->psuSlider->maximum();
     int tempCounter = 0;
     while(tempInt>90){
-        sprintf(tempString, "%dV", tempInt/20);
-        ui->psuSlider->setTickLabel(tempString, tempCounter);
+        ui->psuSlider->setTickLabel(QString("%1V").arg(tempInt/20), tempCounter);
         tempInt -= 20;
         tempCounter++;
     }
@@ -2157,8 +2155,7 @@ void MainWindow::fileLimitReached_CH1(void){
     ui->actionRecord_CH1->setChecked(false);
 
     QMessageBox recordingStoppedMessageBox;
-    char recordingStoppedMessage[256];
-    sprintf(recordingStoppedMessage, "Maximum file size limit of %uMB reached.  Data Acquisition Stopped.", daq_max_file_size/1000000);
+    QString recordingStoppedMessage = QString("Maximum file size limit of %1MB reached.  Data Acquisition Stopped.").arg(daq_max_file_size/1000000);
     recordingStoppedMessageBox.setText(recordingStoppedMessage);
     recordingStoppedMessageBox.exec();
 }
@@ -2167,8 +2164,7 @@ void MainWindow::fileLimitReached_CH2(void){
     ui->actionRecord_CH2->setChecked(false);
 
     QMessageBox recordingStoppedMessageBox;
-    char recordingStoppedMessage[256];
-    sprintf(recordingStoppedMessage, "Maximum file size limit of %uMB reached.  Data Acquisition Stopped.", daq_max_file_size/1000000);
+    QString recordingStoppedMessage = QString("Maximum file size limit of %1MB reached.  Data Acquisition Stopped.").arg(daq_max_file_size/1000000);
     recordingStoppedMessageBox.setText(recordingStoppedMessage);
     recordingStoppedMessageBox.exec();
 }


### PR DESCRIPTION
This fixes a handful of warnings where the format strings disagree with the variable type, plus replacing a deprecated function.

As an aside, Qt's string handling is really inconsistent so there are 4 different styles here.  `QString::arg` is the preferred type-safe way to do string formatting, except it doesn't support `const char *` and you have to use `QString::asprintf`.  `qDebug` supports C-style format strings and the safer but uglier C++-style stream insertion, but `qFatal` only supports the format strings.