### PR TITLE
Restore exec.so to the AppImage

### DIFF
--- a/Desktop_Interface/make_appimage
+++ b/Desktop_Interface/make_appimage
@@ -5,13 +5,18 @@ set -e
 qmake APPIMAGE=1 CONFIG+=release PREFIX=/usr DEFINES+=GIT_HASH_SHORT=$(git rev-parse --short HEAD)
 make -j$(nproc) ${CC:+CC=${CC}} ${CXX:+CXX=${CXX} LINK=${CXX}}
 make INSTALL_ROOT=AppDir install ; find AppDir/
+
 wget -N -nv "https://github.com/probonopd/linuxdeployqt/releases/download/6/linuxdeployqt-6-x86_64.AppImage"
 chmod a+x linuxdeployqt-*.AppImage
 unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
 export VERSION=$(git rev-parse --short HEAD)
 ./linuxdeployqt-*.AppImage AppDir/usr/share/applications/*.desktop -bundle-non-qt-libs -verbose=2 -no-strip -unsupported-allow-new-glibc
-#mkdir -p AppDir/usr/optional/ ; wget https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so -O ./AppDir/usr/optional/exec.so
+
 mkdir -p AppDir/usr/optional/libstdc++/ ; cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 ./AppDir/usr/optional/libstdc++/
+
+wget -N -nv https://github.com/darealshinji/linuxdeploy-plugin-checkrt/raw/refs/heads/master/exec.c
+cc -shared -O2 -fPIC exec.c -o AppDir/usr/optional/exec.so -Wl,--as-needed -static-libgcc -ldl -s
+
 ./linuxdeployqt-*.AppImage --appimage-extract
 rm ./AppDir/AppRun ; cp ./resources/AppRun AppDir/ ; chmod a+x ./AppDir/AppRun
 PATH=./squashfs-root/usr/bin:$PATH ./squashfs-root/usr/bin/appimagetool -g ./AppDir/


### PR DESCRIPTION
Build it from source instead of trying to fetch a prebuilt copy.

Fixes lingering issues from #290.