### PR TITLE
Warning fixes

### DIFF
--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -269,20 +269,21 @@ void isoDriver::setVoltageRange(QWheelEvent* event)
 
 void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused, double maxWindowSize, QCustomPlot* axes)
 {
+    double steps = event->delta() / 120.0;
     if (!(event->modifiers() == Qt::ControlModifier) && event->orientation() == Qt::Orientation::Vertical) {
         double c = (topRange - botRange) / (double)400;
 
         QCPRange range = axes->yAxis->range();
 
         double pixPct = (double)100 - ((double)100 * (((double)axes->yAxis->pixelToCoord(event->y())-range.lower) / range.size()));
-        if (pixPct < 0) pixPct = 0; 
+        if (pixPct < 0) pixPct = 0;
         if (pixPct > 100) pixPct = 100;
 
         qDebug() << "WHEEL @ " << pixPct << "%";
         qDebug() << range.upper;
 
-        topRange -= event->delta() / 120.0 * c * pixPct;
-        botRange += event->delta() / 120.0 * c * (100.0 - pixPct);
+        topRange -= steps * c * pixPct;
+        botRange += steps * c * (100.0 - pixPct);
 
         if (topRange > (double)20) topRange = (double)20;
         if (botRange < -(double)20) botRange = (double)-20;
@@ -306,7 +307,6 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
             pixPct = 100;
 
         qDebug() << "WHEEL @ " << pixPct << "%";
-        qDebug() << event->delta();
 
         if (! isProperlyPaused)
         {
@@ -317,8 +317,8 @@ void DisplayControl::setVoltageRange (QWheelEvent* event, bool isProperlyPaused,
             qDebug() << c * ((double)100 - (double)pixPct) * pixPct / 100;
         }
 
-        window -= event->delta() / 120.0 * c * pixPct;
-        delay += event->delta() / 120.0 * c * (100.0 - pixPct) * pixPct / 100.0;
+        window -= steps * c * pixPct;
+        delay += steps * c * (100.0 - pixPct) * pixPct / 100.0;
 
         // NOTE: delayUpdated and timeWindowUpdated are called more than once beyond here,
         // maybe they should only be called once at the end?
@@ -617,7 +617,7 @@ void isoDriver::setTriggerMode(int newMode)
 }
 
 //0 for off, 1 for ana, 2 for dig, -1 for ana750, -2 for file
-void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)  
+void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
 {
     // The Spectrum is computationally expensive to calculate, so we don't want to do it on every frame
     static int spectrumCounter = 0;
@@ -774,7 +774,7 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
             CH2[i] /= m_attenuation_CH2;
             CH2[i] += m_offset_CH2;
         }
-        
+
         if (spectrum)
         {
             analogConvert(dt_samples2.get(), &converted_dt_samples2, 128, AC_CH2, 2);
@@ -1369,7 +1369,7 @@ void isoDriver::setXYmode(bool enabled){
             axes->graph(i)->setVisible(graphState[i]);
         }
     }
-    
+
     QCPCurve* curve = reinterpret_cast<QCPCurve*>(axes->plottable(0));
     curve->setVisible(enabled);
     emit enableCursorGroup(!enabled);
@@ -1858,4 +1858,3 @@ void isoDriver::restartFreqResp()
 {
     m_freqRespFlag = true;
 }
-

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -157,7 +157,7 @@ MainWindow::MainWindow(QWidget *parent) :
         connect(ui->bufferDisplay, SIGNAL(modeChange(int)), ui->controller_iso->driver, SLOT(setDeviceMode(int)));
 		connect(ui->bufferDisplay, &bufferControl::modeChange, this, [this](){
 			// Force a trigger refresh
-			ui->controller_iso->setTriggerLevel(ui->triggerLevelValue->value());	
+			ui->controller_iso->setTriggerLevel(ui->triggerLevelValue->value());
 		});
         connect(ui->bufferDisplay, SIGNAL(updateDig(int)), ui->controller_iso->driver, SLOT(newDig(int)));
 
@@ -214,7 +214,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->realTimeButton, SIGNAL(pressed()), ui->controller_iso, SLOT(disableFileMode()));
 
 
-	
+
     connect(ui->pausedLabeL_CH1, SIGNAL(toggled(bool)), this, SLOT(paused(bool)));
     connect(ui->pausedLabel_CH2, SIGNAL(toggled(bool)), this, SLOT(paused(bool)));
     connect(ui->pause_LA, SIGNAL(toggled(bool)), this, SLOT(paused(bool)));
@@ -232,9 +232,10 @@ MainWindow::MainWindow(QWidget *parent) :
 #endif
     ui->realTimeButton->setVisible(false);
 
-    if ((QApplication::desktop()->availableGeometry().width() < 1520) || (QApplication::desktop()->geometry().height() < 800))
+    auto geom = QGuiApplication::primaryScreen()->availableGeometry();
+    if ((geom.width() < 1520) || (geom.height() < 800))
     {
-        qDebug() << "Low resolution detected:" << QApplication::desktop()->availableGeometry().width() << "x" << QApplication::desktop()->availableGeometry().height();
+        qDebug() << "Low resolution detected:" << geom.width() << "x" << geom.height();
         this->setMinimumSize(1280, 700);
         this->resize(1280, 700);
     }
@@ -1459,7 +1460,7 @@ void MainWindow::reinitUsbStage2(void){
     connect(ui->bufferDisplay, SIGNAL(modeChange(int)), ui->controller_iso->driver, SLOT(setDeviceMode(int)));
 	connect(ui->bufferDisplay, &bufferControl::modeChange, this, [this](){
 		// Force a trigger refresh
-		ui->controller_iso->setTriggerLevel(ui->triggerLevelValue->value());	
+		ui->controller_iso->setTriggerLevel(ui->triggerLevelValue->value());
 	});
     connect(ui->bufferDisplay, SIGNAL(updateDig(int)), ui->controller_iso->driver, SLOT(newDig(int)));
 
@@ -2480,7 +2481,7 @@ void MainWindow::paused(bool enabled)
 	qDebug() << "MainWindow::paused(" << enabled << ")";
 	ui->hideCH1Box->setVisible(enabled);
 	ui->hideCH2Box->setVisible(enabled);
-	
+
 	if (! enabled)
 	{
 		ui->hideCH1Box->setChecked(false);
@@ -2548,7 +2549,7 @@ void MainWindow::cursorGroupEnabled(bool enabled)
         ui->makeCursorsNicer->setTurnedOn(false);
         ui->cursorGroup->setEnabled(false);
     }
-    
+
 }
 
 void MainWindow::on_actionHide_Widget_Oscilloscope_triggered(bool checked)
@@ -2816,4 +2817,3 @@ void MainWindow::on_txuart_textChanged()
         prev_text = text;
     }
 }
-

--- a/Desktop_Interface/ui_elements/esposlider.cpp
+++ b/Desktop_Interface/ui_elements/esposlider.cpp
@@ -42,10 +42,10 @@ void espoSlider::moveEvent(QMoveEvent *event){
 
 
 void espoSlider::setTickInterval(int ti){
-    addressBook.resize(maxTick(ti) + 1, NULL); //Leaky, but not significantly.  Old qlabels never deleted.
-    for (int i=0; i<addressBook.size();i++){
-        if (addressBook.at(i)==NULL)
-            addressBook.at(i) = new QLabel(windowPointer);
+    addressBook.resize(maxTick(ti) + 1, nullptr); //Leaky, but not significantly.  Old qlabels never deleted.
+    for (auto &it : addressBook){
+        if (!it)
+            it = new QLabel(windowPointer);
     }
     QSlider::setTickInterval(ti);
     return;
@@ -103,4 +103,3 @@ void espoSlider::poke(void){
     //qDebug() << "Refreshing to voltage" <<  ((double) (this->value())) / 20;
     voltageChanged(((double) (this->value())) / 20);
 }
-

--- a/Desktop_Interface/unixusbdriver.cpp
+++ b/Desktop_Interface/unixusbdriver.cpp
@@ -28,7 +28,7 @@ unixUsbDriver::~unixUsbDriver(void){
 				qDebug() << "isRunning?" << workerThread->isFinished();
 				QThread::msleep(100);
 			}
-		}	
+		}
 		if (isoHandler)
 	        delete(isoHandler);
         //delete(workerThread);
@@ -143,7 +143,7 @@ static void LIBUSB_CALL isoCallback(struct libusb_transfer * transfer){
 
 int unixUsbDriver::usbIsoInit(void){
     int error;
-	
+
     for(int n=0;n<NUM_FUTURE_CTX;n++){
         for (unsigned char k=0;k<NUM_ISO_ENDPOINTS;k++){
             isoCtx[k][n] = libusb_alloc_transfer(ISO_PACKETS_PER_CTX);
@@ -214,7 +214,7 @@ void unixUsbDriver::isoTimerTick(void){
     int n, error, earliest = MAX_OVERLAP;
     qint64 minFrame = 9223372036854775807; //max value for 64 bit signed
 
-    unsigned int i, packetLength = 0;
+    unsigned int packetLength = 0;
     unsigned char* packetPointer;
 
     tcBlockMutex.lock();
@@ -244,7 +244,7 @@ void unixUsbDriver::isoTimerTick(void){
     }
 
     //Copy iso data into mid-buffer
-    for(i=0;i<isoCtx[0][earliest]->num_iso_packets;i++){
+    for(int i=0;i<isoCtx[0][earliest]->num_iso_packets;i++){
         for(unsigned char k=0; k<NUM_ISO_ENDPOINTS;k++){
             packetPointer = libusb_get_iso_packet_buffer_simple(isoCtx[k][earliest], i);
             //qDebug() << packetLength;
@@ -257,7 +257,7 @@ void unixUsbDriver::isoTimerTick(void){
     //Read out from mid-buffer to out-buffer
     unsigned char *srcPtr;
     qint64 current_offset;
-    for(i=0;i<isoCtx[0][earliest]->num_iso_packets;i++){
+    for(int i=0;i<isoCtx[0][earliest]->num_iso_packets;i++){
         for(unsigned char k=0; k<NUM_ISO_ENDPOINTS;k++){
             current_offset = midBufferOffsets[k] + i;
             if(current_offset >= 0){


### PR DESCRIPTION
This is another batch of warning fixes:  Signed/unsigned comparisons, and some Qt deprecations.

The last commit only rearranges things to reduce how many times the compiler complains.  Qt's scroll wheel events got reworked (with a lot of the old methods getting immediately deprecated) in the 5.12 through 5.15 timeframe and we'll eventually need to address that properly.  I don't know what minimum Qt version we want to support.