### PR TITLE
Frequency spinbox updates

### DIFF
--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -1915,14 +1915,14 @@ void isoDriver::setHexDisplay_CH2(bool enabled)
     hexDisplay_CH2 = enabled;
 }
 
-void isoDriver::setMinSpectrum(int minSpectrum)
+void isoDriver::setMinSpectrum(double minSpectrum)
 {
-    m_spectrumMinX = static_cast<double>(minSpectrum);
+    m_spectrumMinX = minSpectrum;
 }
 
-void isoDriver::setMaxSpectrum(int maxSpectrum)
+void isoDriver::setMaxSpectrum(double maxSpectrum)
 {
-    m_spectrumMaxX = static_cast<double>(maxSpectrum);
+    m_spectrumMaxX = maxSpectrum;
 }
 
 void isoDriver::setWindowingType(int windowingType)
@@ -1930,19 +1930,19 @@ void isoDriver::setWindowingType(int windowingType)
     m_windowingType = windowingType;
 }
 
-void isoDriver::setMinFreqResp(int minFreqResp)
+void isoDriver::setMinFreqResp(double minFreqResp)
 {
-    m_freqRespMin = static_cast<double>(minFreqResp);
+    m_freqRespMin = minFreqResp;
     m_freqRespFlag = true;
 }
 
-void isoDriver::setMaxFreqResp(int maxFreqResp)
+void isoDriver::setMaxFreqResp(double maxFreqResp)
 {
-    m_freqRespMax = static_cast<double>(maxFreqResp);
+    m_freqRespMax = maxFreqResp;
     m_freqRespFlag = true;
 }
 
-void isoDriver::setFreqRespStep(int freqRespStep)
+void isoDriver::setFreqRespStep(double freqRespStep)
 {
     m_freqRespStep = freqRespStep;
     m_freqRespFlag = true;

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -202,7 +202,7 @@ private:
     QVector<double> m_freqRespPhase;
     double m_freqRespMin = 100;
     double m_freqRespMax = 32500;
-    int m_freqRespStep = 100;
+    double m_freqRespStep = 100;
     int m_freqRespType = 0;
     bool m_freqRespFlag = false;
 
@@ -302,12 +302,12 @@ public slots:
     void attenuationChanged_CH2(int attenuationIndex);
     void setHexDisplay_CH1(bool enabled);
     void setHexDisplay_CH2(bool enabled);
-    void setMinSpectrum(int minSpectrum);
-    void setMaxSpectrum(int maxSpectrum);
+    void setMinSpectrum(double minSpectrum);
+    void setMaxSpectrum(double maxSpectrum);
     void setWindowingType(int windowing);
-    void setMinFreqResp(int minFreqResp);
-    void setMaxFreqResp(int maxFreqResp);
-    void setFreqRespStep(int stepFreqResp);
+    void setMinFreqResp(double minFreqResp);
+    void setMaxFreqResp(double maxFreqResp);
+    void setFreqRespStep(double stepFreqResp);
     void setFreqRespType(int typeFreqResp);
     void restartFreqResp();
 };

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -255,19 +255,21 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->controller_iso, &isoDriver::enableCursorGroup, this, &MainWindow::cursorGroupEnabled);
 
     // Frequency spectrum
-    spectrumMinXSpinbox = new QSpinBox();
-    spectrumMaxXSpinbox = new QSpinBox();
+    spectrumMinXSpinbox = new espoSpinBox();
+    spectrumMaxXSpinbox = new espoSpinBox();
     windowingComboBox = new QComboBox();
     spectrumLayoutWidget = new QWidget();
     QHBoxLayout* spectrumLayout = new QHBoxLayout(spectrumLayoutWidget);
-    QLabel* spectrumMinFreqLabel = new QLabel("Min Frequency (Hz)");
-    QLabel* spectrumMaxFreqLabel = new QLabel("Max Frequency (Hz)");
+    QLabel* spectrumMinFreqLabel = new QLabel("Min Frequency");
+    QLabel* spectrumMaxFreqLabel = new QLabel("Max Frequency");
     QLabel* windowingLabel = new QLabel("Window");
     QSpacerItem* spacer = new QSpacerItem(20, 40, QSizePolicy::Expanding, QSizePolicy::Minimum);
 
     spectrumLayoutWidget->setLayout(spectrumLayout);
+    spectrumMinXSpinbox->setSuffix(QString::fromUtf8("Hz"));
     spectrumMinXSpinbox->setMinimum(0);
     spectrumMinXSpinbox->setMaximum(375000);
+    spectrumMaxXSpinbox->setSuffix(QString::fromUtf8("Hz"));
     spectrumMaxXSpinbox->setMinimum(0);
     spectrumMaxXSpinbox->setMaximum(375000);
     spectrumMaxXSpinbox->setValue(375000);
@@ -289,12 +291,15 @@ MainWindow::MainWindow(QWidget *parent) :
     spectrumLayout->addWidget(windowingComboBox);
     spectrumLayout->addItem(spacer);
 
-    connect(spectrumMinXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMinSpectrum);
-    connect(spectrumMaxXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMaxSpectrum);
+    connect(spectrumMinXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMinSpectrum);
+    connect(spectrumMaxXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMaxSpectrum);
     connect(windowingComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), ui->controller_iso, &isoDriver::setWindowingType);
 
-    connect(spectrumMinXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), spectrumMaxXSpinbox, &QSpinBox::setMinimum);
-    connect(spectrumMaxXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), spectrumMinXSpinbox, &QSpinBox::setMaximum);
+    connect(spectrumMinXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), spectrumMaxXSpinbox, &espoSpinBox::setMinimum);
+    connect(spectrumMaxXSpinbox, QOverload<double>::of(&espoSpinBox::valueChanged), spectrumMinXSpinbox, &espoSpinBox::setMaximum);
+
+    connect(spectrumMinXSpinbox, SIGNAL(valueChanged(double)), spectrumMinXSpinbox, SLOT(changeStepping(double)));
+    connect(spectrumMaxXSpinbox, SIGNAL(valueChanged(double)), spectrumMaxXSpinbox, SLOT(changeStepping(double)));
 
     ui->verticalLayout->addWidget(spectrumLayoutWidget);
     spectrumLayoutWidget->setVisible(false);

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -269,10 +269,13 @@ MainWindow::MainWindow(QWidget *parent) :
     spectrumMinXSpinbox->setSuffix(QString::fromUtf8("Hz"));
     spectrumMinXSpinbox->setMinimum(0);
     spectrumMinXSpinbox->setMaximum(375000);
+    spectrumMinXSpinbox->setValue(0);
+    spectrumMinXSpinbox->setSingleStep(1000);
     spectrumMaxXSpinbox->setSuffix(QString::fromUtf8("Hz"));
     spectrumMaxXSpinbox->setMinimum(0);
     spectrumMaxXSpinbox->setMaximum(375000);
     spectrumMaxXSpinbox->setValue(375000);
+    spectrumMaxXSpinbox->setSingleStep(10000);
     windowingComboBox->addItem("Rectangular");
     windowingComboBox->addItem("Hann");
     windowingComboBox->addItem("Hamming");
@@ -324,10 +327,12 @@ MainWindow::MainWindow(QWidget *parent) :
     freqRespMinXSpinbox->setMinimum(100);
     freqRespMinXSpinbox->setMaximum(62500);
     freqRespMinXSpinbox->setValue(100);
+    freqRespMinXSpinbox->setSingleStep(10);
     freqRespMaxXSpinbox->setSuffix(QString::fromUtf8("Hz"));
     freqRespMaxXSpinbox->setMinimum(100);
     freqRespMaxXSpinbox->setMaximum(62500);
     freqRespMaxXSpinbox->setValue(32500);
+    freqRespMaxXSpinbox->setSingleStep(1000);
 
     freqRespLayout1->addItem(spacer);
     freqRespLayout1->addWidget(freqRespMinFreqLabel);
@@ -342,6 +347,7 @@ MainWindow::MainWindow(QWidget *parent) :
     freqRespStepSpinbox->setMinimum(10);
     freqRespStepSpinbox->setMaximum(10000);
     freqRespStepSpinbox->setValue(100);
+    freqRespStepSpinbox->setSingleStep(10);
     freqRespTypeComboBox->addItem("Gain");
     freqRespTypeComboBox->addItem("Phase");
     freqRespTypeComboBox->setCurrentIndex(0);

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -267,13 +267,11 @@ MainWindow::MainWindow(QWidget *parent) :
 
     spectrumLayoutWidget->setLayout(spectrumLayout);
     spectrumMinXSpinbox->setSuffix(QString::fromUtf8("Hz"));
-    spectrumMinXSpinbox->setMinimum(0);
-    spectrumMinXSpinbox->setMaximum(375000);
+    spectrumMinXSpinbox->setRange(0, 375000);
     spectrumMinXSpinbox->setValue(0);
     spectrumMinXSpinbox->setSingleStep(1000);
     spectrumMaxXSpinbox->setSuffix(QString::fromUtf8("Hz"));
-    spectrumMaxXSpinbox->setMinimum(0);
-    spectrumMaxXSpinbox->setMaximum(375000);
+    spectrumMaxXSpinbox->setRange(0, 375000);
     spectrumMaxXSpinbox->setValue(375000);
     spectrumMaxXSpinbox->setSingleStep(10000);
     windowingComboBox->addItem("Rectangular");
@@ -324,13 +322,11 @@ MainWindow::MainWindow(QWidget *parent) :
 
     freqRespLayout1Widget->setLayout(freqRespLayout1);
     freqRespMinXSpinbox->setSuffix(QString::fromUtf8("Hz"));
-    freqRespMinXSpinbox->setMinimum(100);
-    freqRespMinXSpinbox->setMaximum(62500);
+    freqRespMinXSpinbox->setRange(100, 62500);
     freqRespMinXSpinbox->setValue(100);
     freqRespMinXSpinbox->setSingleStep(10);
     freqRespMaxXSpinbox->setSuffix(QString::fromUtf8("Hz"));
-    freqRespMaxXSpinbox->setMinimum(100);
-    freqRespMaxXSpinbox->setMaximum(62500);
+    freqRespMaxXSpinbox->setRange(100, 62500);
     freqRespMaxXSpinbox->setValue(32500);
     freqRespMaxXSpinbox->setSingleStep(1000);
 
@@ -344,8 +340,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
     freqRespLayout2Widget->setLayout(freqRespLayout2);
     freqRespStepSpinbox->setSuffix(QString::fromUtf8("Hz"));
-    freqRespStepSpinbox->setMinimum(10);
-    freqRespStepSpinbox->setMaximum(10000);
+    freqRespStepSpinbox->setRange(10, 10000);
     freqRespStepSpinbox->setValue(100);
     freqRespStepSpinbox->setSingleStep(10);
     freqRespTypeComboBox->addItem("Gain");

--- a/Desktop_Interface/mainwindow.h
+++ b/Desktop_Interface/mainwindow.h
@@ -306,8 +306,8 @@ private:
 
     // Frequency spectrum
     QWidget* spectrumLayoutWidget = nullptr;
-    QSpinBox* spectrumMinXSpinbox = nullptr;
-    QSpinBox* spectrumMaxXSpinbox = nullptr;
+    espoSpinBox* spectrumMinXSpinbox = nullptr;
+    espoSpinBox* spectrumMaxXSpinbox = nullptr;
     QComboBox* windowingComboBox = nullptr;
 
     // Frequency response


### PR DESCRIPTION
This updates the min/max frequency spinboxes on the spectrum mode to match those for the frequency response mode:  SI-prefixed units listed next to the number, and adaptive step sizes for the up/down buttons.  I've also increased the default step size for a better feel (so that the first click increments by about the same amount as the second click, instead of by 1).