### PR TITLE
frequency spectrum analyzer: windowing support

### DIFF
--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -78,7 +78,7 @@ void AsyncDFT::clearWindow()
     samples_count = 0;
 }
 
-QVector<double> AsyncDFT::getPowerSpectrum_dbmv(QVector<double> input, double wind_fact_sum)
+QVector<double> AsyncDFT::getPowerSpectrum_dBmV(QVector<double> input, double wind_fact_sum)
 {
     /*Before doing anything, check if sliding DFT is computable*/
     if (data_valid == false) {
@@ -96,12 +96,12 @@ QVector<double> AsyncDFT::getPowerSpectrum_dbmv(QVector<double> input, double wi
     /*Executing FFTW plan*/
     fftw_execute(plan);
 
-    /* dBmv = 20*log10(|V_fft,mv/N|) - wind_corr
-       dBmv = 20*log10(|V_fft,mv/N|) - 20*log10(∑(Wi)/N)
-       dBmv = 20*log10((10^3) * |V_fft| / N) - 20*log10(∑(Wi) / N)
-       dBmv = 20*(log10(10^3)) + 20*log10(|V_fft|) - 20*log10(N)) - 20*log10(∑Wi) + 20*log10(N)
-       dBmv = 60 + 20*log10(|V_fft|)) - 20*log10(∑Wi)
-       dBmv = 60 + 10*log10(|V_fft|^2) - 20*log10(∑Wi)
+    /* dBmV = 20*log10(|V_fft,mv/N|) - wind_corr
+       dBmV = 20*log10(|V_fft,mv/N|) - 20*log10(∑(Wi)/N)
+       dBmV = 20*log10((10^3) * |V_fft| / N) - 20*log10(∑(Wi) / N)
+       dBmV = 20*(log10(10^3)) + 20*log10(|V_fft|) - 20*log10(N)) - 20*log10(∑Wi) + 20*log10(N)
+       dBmV = 60 + 20*log10(|V_fft|)) - 20*log10(∑Wi)
+       dBmV = 60 + 10*log10(|V_fft|^2) - 20*log10(∑Wi)
     */
     for (int k = 0; k <= (n_samples+1)/2; ++k) {
          amplitude[k] = 60 + 10*std::log10(out_buffer[k][0]*out_buffer[k][0] + out_buffer[k][1]*out_buffer[k][1]) - 20*std::log10(wind_fact_sum);

--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -78,7 +78,7 @@ void AsyncDFT::clearWindow()
     samples_count = 0;
 }
 
-QVector<double> AsyncDFT::getPowerSpectrum(QVector<double> input)
+QVector<double> AsyncDFT::getPowerSpectrum_db(QVector<double> input)
 {
     /*Before doing anything, check if sliding DFT is computable*/
     if (data_valid == false) {
@@ -95,17 +95,17 @@ QVector<double> AsyncDFT::getPowerSpectrum(QVector<double> input)
 
     /*Executing FFTW plan*/
     fftw_execute(plan);
-    amplitude[0] = sqrt(out_buffer[0][0]*out_buffer[0][0] + out_buffer[0][1]*out_buffer[0][1]);  /* DC component */
+    amplitude[0] = 10*(6+std::log10(out_buffer[0][0]*out_buffer[0][0] + out_buffer[0][1]*out_buffer[0][1])-10.235019853);  /* DC component */
 
     maximum = (amplitude[0] > maximum ) ? amplitude[0] : maximum;
 
     for (int k = 1; k < (n_samples+1)/2; ++k) {  /* (k < N/2 rounded up) */
-         amplitude[k] = sqrt(out_buffer[k][0]*out_buffer[k][0] + out_buffer[k][1]*out_buffer[k][1]);
+         amplitude[k] = 10*(6+std::log10(out_buffer[k][0]*out_buffer[k][0] + out_buffer[k][1]*out_buffer[k][1])-10.235019853);
 
          maximum = (amplitude[k] > maximum ) ? amplitude[k] : maximum;
     }
     if (n_samples % 2 == 0) { /* N is even */
-         amplitude[n_samples/2] = sqrt(out_buffer[n_samples/2][0]*out_buffer[n_samples/2][0]);  /* Nyquist freq. */
+         amplitude[n_samples/2] = 10*(6+std::log10(out_buffer[n_samples/2][0]*out_buffer[n_samples/2][0])-10.235019853);  /* Nyquist freq. */
 
          maximum = (amplitude[n_samples/2] > maximum ) ? amplitude[n_samples/2] : maximum;
 

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -16,7 +16,7 @@ public:
     static const int n_samples = 1<<17;
 
     /* Raise exception if not ready yet*/
-    QVector<double> getPowerSpectrum_dbmv(QVector<double> input, double wind_fact_sum);
+    QVector<double> getPowerSpectrum_dBmV(QVector<double> input, double wind_fact_sum);
     QVector<double> getFrequenciyWindow(int samplesPerSeconds);
 
     /*Add a sample to the time domain samples*/

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -16,7 +16,7 @@ public:
     static const int n_samples = 1<<17;
 
     /* Raise exception if not ready yet*/
-    QVector<double> getPowerSpectrum_db(QVector<double> input, double wind_fact_sum);
+    QVector<double> getPowerSpectrum_dbmv(QVector<double> input, double wind_fact_sum);
     QVector<double> getFrequenciyWindow(int samplesPerSeconds);
 
     /*Add a sample to the time domain samples*/

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -16,7 +16,7 @@ public:
     static const int n_samples = 1<<17;
 
     /* Raise exception if not ready yet*/
-    QVector<double> getPowerSpectrum_db(QVector<double> input);
+    QVector<double> getPowerSpectrum_db(QVector<double> input, double wind_fact_sum);
     QVector<double> getFrequenciyWindow(int samplesPerSeconds);
 
     /*Add a sample to the time domain samples*/

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -16,7 +16,7 @@ public:
     static const int n_samples = 1<<17;
 
     /* Raise exception if not ready yet*/
-    QVector<double> getPowerSpectrum(QVector<double> input);
+    QVector<double> getPowerSpectrum_db(QVector<double> input);
     QVector<double> getFrequenciyWindow(int samplesPerSeconds);
 
     /*Add a sample to the time domain samples*/

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -904,9 +904,9 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
                 /*Creating DFT amplitudes*/
                 QVector<double> amplitude1;
                 if(CH1_mode == -1)
-                    amplitude1 = internalBuffer750->async_dft->getPowerSpectrum_dbmv(converted_dt_samples1, wind_fact_sum);
+                    amplitude1 = internalBuffer750->async_dft->getPowerSpectrum_dBmV(converted_dt_samples1, wind_fact_sum);
                 else
-                    amplitude1 = internalBuffer375_CH1->async_dft->getPowerSpectrum_dbmv(converted_dt_samples1, wind_fact_sum);
+                    amplitude1 = internalBuffer375_CH1->async_dft->getPowerSpectrum_dBmV(converted_dt_samples1, wind_fact_sum);
                 /*Getting array of frequencies for display purposes*/
                 QVector<double> f;
                 if(CH1_mode == -1)
@@ -923,16 +923,16 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
                 double max2 = -1;
 
                 if(CH2_mode) {
-                    QVector<double> amplitude2 = internalBuffer375_CH2->async_dft->getPowerSpectrum_dbmv(converted_dt_samples2, wind_fact_sum);
+                    QVector<double> amplitude2 = internalBuffer375_CH2->async_dft->getPowerSpectrum_dBmV(converted_dt_samples2, wind_fact_sum);
                     max2 = internalBuffer375_CH2->async_dft->maximum;
                     axes->graph(1)->setData(f,amplitude2);
                 }
 
                 axes->graph(0)->setData(f, amplitude1);
                 axes->xAxis->setLabel("Frequency (Hz)");
-                axes->yAxis->setLabel("Relative Power (dBmv)");
+                axes->yAxis->setLabel("Relative Power (dBmV)");
                 axes->xAxis->setRange(m_spectrumMinX, m_spectrumMaxX);
-                /*Setting maximum/minimum y-axis -60dbmv to 90dbmv*/
+                /*Setting maximum/minimum y-axis -60dBmV to 90dBmV*/
                 axes->yAxis->setRange(90,-60);
             }  catch (std::exception) {
                 std::cout << "Cannot yet get correct value for DFT" << std::endl;
@@ -1066,7 +1066,7 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
             axes->graph(0)->setData(x,CH1);
             if(CH2_mode) axes->graph(1)->setData(x,CH2);
             axes->xAxis->setLabel("Time (sec)");
-            axes->yAxis->setLabel("Voltage (v)");
+            axes->yAxis->setLabel("Voltage (V)");
             axes->xAxis->setRange(-display.window - display.delay, -display.delay);
             axes->yAxis->setRange(display.topRange, display.botRange);
         }

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -929,6 +929,8 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
                 }
 
                 axes->graph(0)->setData(f, amplitude1);
+                axes->xAxis->setLabel("Frequency (Hz)");
+                axes->yAxis->setLabel("Relative Power (dBmv)");
                 axes->xAxis->setRange(m_spectrumMinX, m_spectrumMaxX);
                 /*Setting maximum/minimum y-axis -60dbmv to 90dbmv*/
                 axes->yAxis->setRange(90,-60);
@@ -1043,9 +1045,11 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
             }
 
             // Plot gain response
+            axes->xAxis->setLabel("Frequency (Hz)");
             if(m_freqRespType == 0)
             {
                 axes->graph(0)->setData(m_freqRespFreq, m_freqRespGain);
+                axes->yAxis->setLabel("Gain (dB)");
                 axes->xAxis->setRange(m_freqRespMin-10, m_freqRespMax+10);
                 axes->yAxis->setRange(*std::min_element(m_freqRespGain.constBegin(), m_freqRespGain.constEnd())-10, *std::max_element(m_freqRespGain.constBegin(), m_freqRespGain.constEnd())+10);
             }
@@ -1053,6 +1057,7 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
             else
             {
                 axes->graph(0)->setData(m_freqRespFreq, m_freqRespPhase);
+                axes->yAxis->setLabel("Phase (degree)");
                 axes->xAxis->setRange(m_freqRespMin-10, m_freqRespMax+10);
                 axes->yAxis->setRange(*std::min_element(m_freqRespPhase.constBegin(), m_freqRespPhase.constEnd())-10, *std::max_element(m_freqRespPhase.constBegin(), m_freqRespPhase.constEnd())+10);
             }
@@ -1060,9 +1065,13 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
         } else {
             axes->graph(0)->setData(x,CH1);
             if(CH2_mode) axes->graph(1)->setData(x,CH2);
+            axes->xAxis->setLabel("Time (sec)");
+            axes->yAxis->setLabel("Voltage (v)");
             axes->xAxis->setRange(-display.window - display.delay, -display.delay);
             axes->yAxis->setRange(display.topRange, display.botRange);
         }
+        axes->xAxis->setLabelColor(Qt::white);
+        axes->yAxis->setLabelColor(Qt::white);
     }
 
     if(snapshotEnabled_CH1){

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -904,9 +904,9 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
                 /*Creating DFT amplitudes*/
                 QVector<double> amplitude1;
                 if(CH1_mode == -1)
-                    amplitude1 = internalBuffer750->async_dft->getPowerSpectrum_db(converted_dt_samples1, wind_fact_sum);
+                    amplitude1 = internalBuffer750->async_dft->getPowerSpectrum_dbmv(converted_dt_samples1, wind_fact_sum);
                 else
-                    amplitude1 = internalBuffer375_CH1->async_dft->getPowerSpectrum_db(converted_dt_samples1, wind_fact_sum);
+                    amplitude1 = internalBuffer375_CH1->async_dft->getPowerSpectrum_dbmv(converted_dt_samples1, wind_fact_sum);
                 /*Getting array of frequencies for display purposes*/
                 QVector<double> f;
                 if(CH1_mode == -1)
@@ -923,7 +923,7 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
                 double max2 = -1;
 
                 if(CH2_mode) {
-                    QVector<double> amplitude2 = internalBuffer375_CH2->async_dft->getPowerSpectrum_db(converted_dt_samples2, wind_fact_sum);
+                    QVector<double> amplitude2 = internalBuffer375_CH2->async_dft->getPowerSpectrum_dbmv(converted_dt_samples2, wind_fact_sum);
                     max2 = internalBuffer375_CH2->async_dft->maximum;
                     axes->graph(1)->setData(f,amplitude2);
                 }

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -133,6 +133,7 @@ private:
     //Generic Functions
     void analogConvert(short *shortPtr, QVector<double> *doublePtr, int TOP, bool AC, int channel);
     void digitalConvert(short *shortPtr, QVector<double> *doublePtr);
+    double windowing_factor(int m_windowingType, int n_samples, int index);
     void fileStreamConvert(float *floatPtr, QVector<double> *doublePtr);
     bool properlyPaused();
     void udateCursors(void);
@@ -194,6 +195,7 @@ private:
     //Spectrum
     double m_spectrumMinX = 0;
     double m_spectrumMaxX = 375000;
+    int m_windowingType = 0;
     //Frequency response
     QVector<double> m_freqRespFreq;
     QVector<double> m_freqRespGain;
@@ -302,6 +304,7 @@ public slots:
     void setHexDisplay_CH2(bool enabled);
     void setMinSpectrum(int minSpectrum);
     void setMaxSpectrum(int maxSpectrum);
+    void setWindowingType(int windowing);
     void setMinFreqResp(int minFreqResp);
     void setMaxFreqResp(int maxFreqResp);
     void setFreqRespStep(int stepFreqResp);

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -257,10 +257,12 @@ MainWindow::MainWindow(QWidget *parent) :
     // Frequency spectrum
     spectrumMinXSpinbox = new QSpinBox();
     spectrumMaxXSpinbox = new QSpinBox();
+    windowingComboBox = new QComboBox();
     spectrumLayoutWidget = new QWidget();
     QHBoxLayout* spectrumLayout = new QHBoxLayout(spectrumLayoutWidget);
     QLabel* spectrumMinFreqLabel = new QLabel("Min Frequency (Hz)");
     QLabel* spectrumMaxFreqLabel = new QLabel("Max Frequency (Hz)");
+    QLabel* windowingLabel = new QLabel("Window");
     QSpacerItem* spacer = new QSpacerItem(20, 40, QSizePolicy::Expanding, QSizePolicy::Minimum);
 
     spectrumLayoutWidget->setLayout(spectrumLayout);
@@ -269,6 +271,12 @@ MainWindow::MainWindow(QWidget *parent) :
     spectrumMaxXSpinbox->setMinimum(0);
     spectrumMaxXSpinbox->setMaximum(375000);
     spectrumMaxXSpinbox->setValue(375000);
+    windowingComboBox->addItem("Rectangular");
+    windowingComboBox->addItem("Hann");
+    windowingComboBox->addItem("Hamming");
+    windowingComboBox->addItem("Blackman");
+    windowingComboBox->addItem("Flat top");
+    windowingComboBox->setCurrentIndex(0);
 
     spectrumLayout->addItem(spacer);
     spectrumLayout->addWidget(spectrumMinFreqLabel);
@@ -277,9 +285,13 @@ MainWindow::MainWindow(QWidget *parent) :
     spectrumLayout->addWidget(spectrumMaxFreqLabel);
     spectrumLayout->addWidget(spectrumMaxXSpinbox);
     spectrumLayout->addItem(spacer);
+    spectrumLayout->addWidget(windowingLabel);
+    spectrumLayout->addWidget(windowingComboBox);
+    spectrumLayout->addItem(spacer);
 
     connect(spectrumMinXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMinSpectrum);
     connect(spectrumMaxXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), ui->controller_iso, &isoDriver::setMaxSpectrum);
+    connect(windowingComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), ui->controller_iso, &isoDriver::setWindowingType);
 
     connect(spectrumMinXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), spectrumMaxXSpinbox, &QSpinBox::setMinimum);
     connect(spectrumMaxXSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), spectrumMinXSpinbox, &QSpinBox::setMaximum);

--- a/Desktop_Interface/mainwindow.h
+++ b/Desktop_Interface/mainwindow.h
@@ -308,6 +308,7 @@ private:
     QWidget* spectrumLayoutWidget = nullptr;
     QSpinBox* spectrumMinXSpinbox = nullptr;
     QSpinBox* spectrumMaxXSpinbox = nullptr;
+    QComboBox* windowingComboBox = nullptr;
 
     // Frequency response
     QWidget* freqRespLayout1Widget = nullptr;


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/espotek-org/Labrador/issues/289

List of changes included in the PR
1. amplitude percentage -> dbmv
2. apply windowing functions (Rectangular, Hann, Hamming, Blackman, Flat top)
3. Set maximum/minimum y-axis to -60dbmv to 90dbmv
4. windowing QLabel

And here is a spectrum analyzer output for 3Vpp 1KHz sinusoidal signal
![rectangular](https://github.com/user-attachments/assets/e24f2443-c442-4924-a506-f64b210969cb)
Rectangular windowing

![hann](https://github.com/user-attachments/assets/6fd55aad-a8aa-42cb-bc47-74bba25090a3)
Hann windowing