### PR TITLE
Fixes for Raspberry Pi

### DIFF
--- a/Desktop_Interface/functiongencontrol.cpp
+++ b/Desktop_Interface/functiongencontrol.cpp
@@ -23,8 +23,8 @@ void SingleChannelController::waveformName(QString newName)
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
         qFatal("could not open %s", qUtf8Printable(file.fileName()));
 
-    int length = file.readLine().toInt();
-    m_data.divisibility = file.readLine().toInt();
+    int length = file.readLine().trimmed().toInt();
+    m_data.divisibility = file.readLine().trimmed().toInt();
     QByteArray data = file.readLine().trimmed();
     file.close();
 

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -2785,7 +2785,7 @@ void MainWindow::on_txuart_textChanged()
 
     // Check if key pressed in backspace
     if (text.length() == prev_text.length()-1)
-        new_char = '\b';
+        new_char = "\b";
     else
         new_char = text.right(1);
 
@@ -2794,7 +2794,7 @@ void MainWindow::on_txuart_textChanged()
     parity_CH1 = ui->controller_iso->parity_CH1;
 
     // Encode txuart data
-    if (new_char == '\n')
+    if (new_char == "\n")
         new_char = "\r\n";
     data = uartEncode(new_char, parity_CH1);
 
@@ -2803,7 +2803,7 @@ void MainWindow::on_txuart_textChanged()
     ui->controller_fg->txuartUpdate(ChannelID::CH1, baudRate_CH1, data);
 
     // Check if the last character is newline
-    if (new_char == '\r')
+    if (new_char == "\r")
     {
         // Clear txuart screen
         ui->txuart->clear();

--- a/Desktop_Interface/make_appimage
+++ b/Desktop_Interface/make_appimage
@@ -4,7 +4,7 @@ set -e
 
 rm -rf AppDir
 qmake APPIMAGE=1 CONFIG+=release PREFIX=/usr DEFINES+=GIT_HASH_SHORT=$(git rev-parse --short HEAD)
-make -j$(nproc) ${CC:+CC=${CC}} ${CXX:+CXX=${CXX} LINK=${CXX}}
+make -j$(nproc)
 make INSTALL_ROOT=AppDir install ; find AppDir/
 
 wget -N -nv "https://github.com/probonopd/linuxdeployqt/releases/download/6/linuxdeployqt-6-x86_64.AppImage"

--- a/Desktop_Interface/make_deb
+++ b/Desktop_Interface/make_deb
@@ -3,7 +3,7 @@
 set -e
 
 qmake DEB=1 CONFIG+=release PREFIX=/usr DEFINES+=GIT_HASH_SHORT=$(git rev-parse --short HEAD)
-make -j$(nproc) ${CC:+CC=${CC}} ${CXX:+CXX=${CXX} LINK=${CXX}}
+make -j$(nproc)
 rm -rf deb
 make INSTALL_ROOT=deb install; find deb/
 cp -r resources/debian deb/DEBIAN

--- a/Desktop_Interface/ui_elements/siprint.cpp
+++ b/Desktop_Interface/ui_elements/siprint.cpp
@@ -1,4 +1,5 @@
 #include "siprint.h"
+#include <cmath>
 
 siprint::siprint(const char *unitsInit, double valInit)
 : value(valInit)
@@ -17,41 +18,41 @@ char* siprint::printVal(){
         tempStringPtr++;
     }
 
-    if (abs(value) >= 1000000000000000000)
+    if (std::fabs(value) >= 1000000000000000000)
     {
         sprintf(tempStringPtr, "Inf %s", units);
     }
-    else if (abs(value) >= 1000000)
+    else if (std::fabs(value) >= 1000000)
     {
-        sprintf(tempStringPtr, "%.2fM%s", abs(value)/1000000, units);
+        sprintf(tempStringPtr, "%.2fM%s", std::fabs(value)/1000000, units);
     }
-    else if (abs(value) >= 1000)
+    else if (std::fabs(value) >= 1000)
     {
-        sprintf(tempStringPtr, "%.2fk%s",  abs(value)/1000, units);
+        sprintf(tempStringPtr, "%.2fk%s",  std::fabs(value)/1000, units);
     }
-    else if (abs(value) >= 1)
+    else if (std::fabs(value) >= 1)
     {
-        sprintf(tempStringPtr, "%.2f%s",  abs(value), units);
+        sprintf(tempStringPtr, "%.2f%s",  std::fabs(value), units);
     }
-    else if (abs(value) >= 0.001)
+    else if (std::fabs(value) >= 0.001)
     {
-        sprintf(tempStringPtr, "%.2fm%s", abs(value)*1000, units);
+        sprintf(tempStringPtr, "%.2fm%s", std::fabs(value)*1000, units);
     }
-    else if (abs(value) >= 0.000001)
+    else if (std::fabs(value) >= 0.000001)
     {
-        sprintf(tempStringPtr, "%.2fu%s",  abs(value)*1000000, units);
+        sprintf(tempStringPtr, "%.2fu%s",  std::fabs(value)*1000000, units);
     }
-    else if (abs(value) >= 0.000000001)
+    else if (std::fabs(value) >= 0.000000001)
     {
-        sprintf(tempStringPtr, "%.2fn%s",  abs(value)*1000000000, units);
+        sprintf(tempStringPtr, "%.2fn%s",  std::fabs(value)*1000000000, units);
     }
-    else if (abs(value) >= 0.000000000001)
+    else if (std::fabs(value) >= 0.000000000001)
     {
-        sprintf(tempStringPtr, "%.2fp%s",  abs(value)*1000000000000, units);
+        sprintf(tempStringPtr, "%.2fp%s",  std::fabs(value)*1000000000000, units);
     }
-    else if (abs(value) >= 1)
+    else if (std::fabs(value) >= 1)
     {
-        sprintf(tempStringPtr, "%.2f%s",  abs(value), units);
+        sprintf(tempStringPtr, "%.2f%s",  std::fabs(value), units);
     }
 
     return printString;

--- a/labrador_bootstrap_pi
+++ b/labrador_bootstrap_pi
@@ -25,24 +25,9 @@ fi
 # Move to /tmp so we don't leave junk in the user's folders
 cd /tmp
 
-# Install gcc-8.10, which is modern C++ friendly
-# see https://solarianprogrammer.com/2017/12/08/raspberry-pi-raspbian-install-gcc-compile-cpp-17-programs/
-if [ -d "/usr/local/gcc-8.1.0-labrador" ]; then
-    echo "gcc-8.1.0-labrador is already installed.  Skipping step."
-else
-    rm -rf raspberry-pi-gcc-binary
-    git clone --depth 1 https://github.com/espotek-org/raspberry-pi-gcc-binary
-    cd ./raspberry-pi-gcc-binary
-    tar xf gcc-8.1.0.tar.bz2
-    sudo mv gcc-8.1.0 /usr/local/gcc-8.1.0-labrador
-fi
-
 # Clone the latest version of Labrador
 rm -rf labrador
 git clone --depth 1 https://github.com/espotek-org/labrador
-
-# Set PATH so that make can find gcc-8.10
-export PATH=/usr/local/gcc-8.1.0-labrador/bin:$PATH
 
 # Set QT_SELECT so qtchooser picks the right version
 export QT_SELECT=qt5
@@ -50,11 +35,10 @@ export QT_SELECT=qt5
 # Build labrador
 cd labrador/Desktop_Interface
 qmake
-make CXX=g++-8.1.0 CC=gcc-8.1.0
+make
 sudo make install
 
 # Cleanup
-rm -rf raspberry-pi-gcc-binary
 rm -rf labrador
 
 echo "Labrador installation success!"

--- a/labrador_bootstrap_pi
+++ b/labrador_bootstrap_pi
@@ -1,25 +1,15 @@
 #!/bin/bash
 
-# Install prerequisites
-dpkg -s qtbase5-dev
-QTBASE_NOT_INSTALLED=$?
-dpkg -s qtchooser
-QTCHOOSER_NOT_INSTALLED=$?
-dpkg -s qt5-qmake
-QMAKE_NOT_INSTALLED=$?
-dpkg -s qtbase5-dev-tools
-QTDEV_NOT_INSTALLED=$?
-dpkg -s libusb-1.0-0-dev
-LIBUSB_NOT_INSTALLED=$?
-dpkg -s libfftw3-dev
-FFTW_NOT_INSTALLED=$?
-dpkg -s libeigen3-dev
-EIGEN3_NOT_INSTALLED=$?
-
-# We don't want to bail if one of the first 4 lines returns error.  That's what they're meant to do!
 set -e
 
-if [ $QTBASE_NOT_INSTALLED != 0 ] || [ $QTCHOOSER_NOT_INSTALLED != 0 ] || [ $QMAKE_NOT_INSTALLED != 0 ] || [ $QTDEV_NOT_INSTALLED != 0 ] || [ $LIBUSB_NOT_INSTALLED != 0 ] || [ $FFTW_NOT_INSTALLED != 0 ] || [ $EIGEN3_NOT_INSTALLED != 0 ]; then
+# Install prerequisites
+if ! dpkg -s qtbase5-dev \
+|| ! dpkg -s qtchooser \
+|| ! dpkg -s qt5-qmake \
+|| ! dpkg -s qtbase5-dev-tools \
+|| ! dpkg -s libusb-1.0-0-dev \
+|| ! dpkg -s libfftw3-dev \
+|| ! dpkg -s libeigen3-dev; then
     sudo apt-get update
     sudo apt-get install -y qtbase5-dev
     sudo apt-get install -y qtchooser


### PR DESCRIPTION
I just tested out building/running on a fresh install of Raspbian 9 (Stretch), the oldest version that we're currently claiming to support.  It needed a few tweaks to fix some compilation errors and for apparently some differences in Qt's string-to-integer conversions.

Now there should be nothing special required to build on Raspberry Pi, just the regular `qmake; make; sudo make install`.  The bootstrap script's installation of GCC 8.1 doesn't appear to be necessary since it builds fine with Raspbian's GCC 6.3 and since we're not (yet) using any C++17 features, so I removed it.