### PR TITLE
Clean up firmware string operations

### DIFF
--- a/Desktop_Interface/unixusbdriver.cpp
+++ b/Desktop_Interface/unixusbdriver.cpp
@@ -340,10 +340,7 @@ void unixUsbDriver::backupCleanup(){
 
 int unixUsbDriver::flashFirmware(void){
 #ifndef PLATFORM_ANDROID
-    char fname[128];
     qDebug() << "\n\n\n\n\n\n\n\nFIRMWARE MISMATCH!!!!  FLASHING....\n\n\n\n\n\n\n";
-    sprintf(fname, "/firmware/labrafirm_%04x_%02x.hex", EXPECTED_FIRMWARE_VERSION, DEFINED_EXPECTED_VARIANT);
-    qDebug() << "FLASHING " << fname;
 
     signalFirmwareFlash();
     QApplication::processEvents();
@@ -353,11 +350,9 @@ int unixUsbDriver::flashFirmware(void){
     qDebug() << "BA94 closed";
 
     //Get location of firmware file
-    QString dirString = QCoreApplication::applicationDirPath();
-    dirString.append(fname);
-    QByteArray array = dirString.toLocal8Bit();
-    char* buffer = array.data();
-    //qDebug() << buffer;
+    QString firmware_path = QCoreApplication::applicationDirPath();
+    firmware_path.append(QString::asprintf("/firmware/labrafirm_%04x_%02x.hex", EXPECTED_FIRMWARE_VERSION, DEFINED_EXPECTED_VARIANT));
+    qDebug() << "FLASHING" << firmware_path;
 
     //Set up interface to dfuprog
     int exit_code;
@@ -372,7 +367,7 @@ int unixUsbDriver::flashFirmware(void){
     } while (exit_code);
 
     //Run stage 2
-    snprintf(command, sizeof command, "dfu-programmer atxmega32a4u flash %s", buffer);
+    snprintf(command, sizeof command, "dfu-programmer atxmega32a4u flash %s", qPrintable(firmware_path));
     exit_code = dfuprog_virtual_cmd(command);
     if (exit_code) {
         return exit_code+200;
@@ -411,13 +406,8 @@ int unixUsbDriver::flashFirmware(void){
 void unixUsbDriver::manualFirmwareRecovery(void){
 #ifndef PLATFORM_ANDROID
     //Get location of firmware file
-    char fname[128];
-    sprintf(fname, "/firmware/labrafirm_%04x_%02x.hex", EXPECTED_FIRMWARE_VERSION, DEFINED_EXPECTED_VARIANT);
-
-    QString dirString = QCoreApplication::applicationDirPath();
-    dirString.append(fname);
-    QByteArray array = dirString.toLocal8Bit();
-    char* buffer = array.data();
+    QString firmware_path = QCoreApplication::applicationDirPath();
+    firmware_path.append(QString::asprintf("/firmware/labrafirm_%04x_%02x.hex", EXPECTED_FIRMWARE_VERSION, DEFINED_EXPECTED_VARIANT));
 
     //Set up interface to dfuprog
     int exit_code;
@@ -472,7 +462,7 @@ void unixUsbDriver::manualFirmwareRecovery(void){
         if (!connected) {
             snprintf(command, sizeof command, "dfu-programmer atxmega32a4u erase --force");
             exit_code = dfuprog_virtual_cmd(command);
-            snprintf(command, sizeof command, "dfu-programmer atxmega32a4u flash %s", buffer);
+            snprintf(command, sizeof command, "dfu-programmer atxmega32a4u flash %s", qPrintable(firmware_path));
             exit_code += dfuprog_virtual_cmd(command);
             manualFirmwareMessages.setText("The bootloader is present, but firmware launch failed.  I've attempted to reprogram it.");
             manualFirmwareMessages.exec();

--- a/Desktop_Interface/unixusbdriver.cpp
+++ b/Desktop_Interface/unixusbdriver.cpp
@@ -424,11 +424,6 @@ void unixUsbDriver::manualFirmwareRecovery(void){
     QByteArray array = dirString.toLocal8Bit();
     char* buffer = array.data();
 
-    //Vars
-    QMessageBox manualFirmwareMessages;
-    int messageBoxReturn;
-
-
     char leaveBootloaderCommand[256];
     sprintf(leaveBootloaderCommand, "dfu-programmer atxmega32a4u launch");
     int exit_code;
@@ -437,24 +432,21 @@ void unixUsbDriver::manualFirmwareRecovery(void){
     char flashCommand[256];
     sprintf(flashCommand, "dfu-programmer atxmega32a4u flash %s", buffer);
 
-
-
-
     //Intro
+    QMessageBox manualFirmwareMessages;
     manualFirmwareMessages.setText("Welcome to the firmware recovery wizard.\nThis tool will attempt various steps to troubleshoot a board with connection issues.\n\nPress OK to continue.");
     manualFirmwareMessages.exec();
-
 
     //Hello, this is IT, can you try turning it off and on again?
     manualFirmwareMessages.setText("Before continuing, please disconnect and reconnect your Labrador board, then wait 10 seconds.\n\nAlso ensure that there are no other instances of the Labrador software running on this machine.");
     manualFirmwareMessages.exec();
     manualFirmwareMessages.setStandardButtons(QMessageBox::Yes|QMessageBox::No);
     manualFirmwareMessages.setText("Did that fix things?");
-    messageBoxReturn = manualFirmwareMessages.exec();
+    int messageBoxReturn = manualFirmwareMessages.exec();
     manualFirmwareMessages.setStandardButtons(QMessageBox::Ok);
-    if(messageBoxReturn == 16384){ //"Yes" is 16384, no is 65536
+    if (messageBoxReturn == QMessageBox::Yes) {
         manualFirmwareMessages.setText("Awesome!  Have fun!");
-        messageBoxReturn = manualFirmwareMessages.exec();
+        manualFirmwareMessages.exec();
         return;
     }
 

--- a/Desktop_Interface/winusbdriver.cpp
+++ b/Desktop_Interface/winusbdriver.cpp
@@ -9,7 +9,7 @@ winUsbDriver::winUsbDriver(QWidget *parent) : genericUsbDriver(parent)
 {
 }
 
-winUsbDriver::~winUsbDriver(void){    
+winUsbDriver::~winUsbDriver(void){
 
     //Like any decent destructor, this just frees resources
 
@@ -87,7 +87,7 @@ void winUsbDriver::usbSendControl(uint8_t RequestType, uint8_t Request, uint16_t
 
     //////////////////////////////////////////////////////////////////////////////////////////
     //IF YOU'RE SEEING AN ERROR, CHECK THAT REQUESTTYPE AND REQUEST ARE FORMATTED AS HEX
-    //////////////////////////////////////////////////////////////////////////////////////////    
+    //////////////////////////////////////////////////////////////////////////////////////////
 
     WINUSB_SETUP_PACKET setupPacket;
     unsigned char controlSuccess;
@@ -422,10 +422,6 @@ void winUsbDriver::manualFirmwareRecovery(void){
     dfuprog_location.append("/firmware/dfu-programmer");
     QProcess dfu_exe;
 
-    //Vars
-    QMessageBox manualFirmwareMessages;
-    int messageBoxReturn;
-
     QStringList leaveBootloaderCommand;
     leaveBootloaderCommand << "atxmega32a4u" << "launch";
     int exit_code;
@@ -434,24 +430,21 @@ void winUsbDriver::manualFirmwareRecovery(void){
     QStringList flashCommand;
     flashCommand << "atxmega32a4u" << "flash" << file_location;
 
-
-
-
     //Intro
+    QMessageBox manualFirmwareMessages;
     manualFirmwareMessages.setText("Welcome to the firmware recovery wizard.\nThis tool will attempt various steps to troubleshoot a board with connection issues.\n\nPress OK to continue.");
     manualFirmwareMessages.exec();
-
 
     //Hello, this is IT, can you try turning it off and on again?
     manualFirmwareMessages.setText("Before continuing, please disconnect and reconnect your Labrador board, then wait 10 seconds.\n\nAlso ensure that there are no other instances of the Labrador software running on this machine.");
     manualFirmwareMessages.exec();
     manualFirmwareMessages.setStandardButtons(QMessageBox::Yes|QMessageBox::No);
     manualFirmwareMessages.setText("Did that fix things?");
-    messageBoxReturn = manualFirmwareMessages.exec();
+    int messageBoxReturn = manualFirmwareMessages.exec();
     manualFirmwareMessages.setStandardButtons(QMessageBox::Ok);
-    if(messageBoxReturn == 16384){ //"Yes" is 16384, no is 65536
+    if (messageBoxReturn == QMessageBox::Yes) {
         manualFirmwareMessages.setText("Awesome!  Have fun!");
-        messageBoxReturn = manualFirmwareMessages.exec();
+        manualFirmwareMessages.exec();
         return;
     }
 


### PR DESCRIPTION
This set of changes removes a bunch of miscellaneous buffers for string formatting, instead using a single QString to hold the path to the firmware, and qPrintable to convert it to a C-style string for the dfu-programmer library.

* Since the C-style string passed to the dfu-programmer is non-const, reinitialize it before every call.  This lets us reuse the same buffer and save some memory.
* Switch to snprintf for safety and to avoid warnings on macOS.
* qPrintable preserves the `toLocal8Bit` conversions.  Output to qDebug should not be converted `toLocal8Bit` since it expects Unicode.

This change was a part of #195 and will make it simpler to move the installed files to FHS-compliant locations.

I've tested this on Linux by changing the expected firmware version to 0006 and back.