### PR TITLE
Link to the correct FFTW threading library

### DIFF
--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -355,8 +355,7 @@ DISTFILES += \
 # Vincenzo added these to get multithreading on Unix fftw
 unix:!macx: LIBS += -fopenmp
 macx: LIBS += -lomp
-unix: LIBS += -lfftw3f_omp
-unix: LIBS += -lfftw3_threads
+unix: LIBS += -lfftw3_omp
 macx: INCLUDEPATH += $$system(brew --prefix)/include
 macx: INCLUDEPATH += $$system(brew --prefix)/include/eigen3
 macx: LIBS += -L$$system(brew --prefix)/lib

--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -237,6 +237,10 @@ macx:LIBS += -L$$PWD/build_mac/libdfuprog/lib -ldfuprog-0.9
 macx:INCLUDEPATH += $$PWD/build_mac/libdfuprog/include
 macx:DEPENDPATH += $$PWD/build_mac/libdfuprog/include
 
+macx: INCLUDEPATH += $$system(brew --prefix)/include
+macx: INCLUDEPATH += $$system(brew --prefix)/include/eigen3
+macx: LIBS += -L$$system(brew --prefix)/lib
+
 macx:QMAKE_LFLAGS += "-undefined dynamic_lookup"
 
 QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.10
@@ -250,6 +254,11 @@ QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.10
 
 unix:SOURCES += unixusbdriver.cpp
 unix:HEADERS += unixusbdriver.h
+
+# For multithreading on Unix fftw
+unix:!macx: LIBS += -fopenmp
+macx: LIBS += -lomp
+unix: LIBS += -lfftw3_omp
 
 #############################################################
 ########       SHARED ANDROID/LINUX GCC FLAGS      #########
@@ -351,11 +360,3 @@ DISTFILES += \
     build_android/package_source/gradle/wrapper/gradle-wrapper.properties \
     build_android/package_source/gradlew.bat \
     build_android/package_source/res/xml/device_filter.xml
-
-# Vincenzo added these to get multithreading on Unix fftw
-unix:!macx: LIBS += -fopenmp
-macx: LIBS += -lomp
-unix: LIBS += -lfftw3_omp
-macx: INCLUDEPATH += $$system(brew --prefix)/include
-macx: INCLUDEPATH += $$system(brew --prefix)/include/eigen3
-macx: LIBS += -L$$system(brew --prefix)/lib

--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -1,6 +1,7 @@
 #include "asyncdft.h"
 #include <iostream>
 #include <math.h>
+#include <omp.h>
 #include "isobuffer.h"
 #define DBG 0
 

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -4,7 +4,6 @@
 #include <QVector>
 #include <mutex>
 #include <queue>
-#include <omp.h>
 #include <list>
 #include <fftw3.h>
 

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -6,7 +6,6 @@
 #include <math.h>
 #include "daqloadprompt.h"
 #include <iostream>
-#include <omp.h>
 
 #define PI 3.141592653589793  // Predefined value for pi
 static constexpr int kSpectrumCounterMax = 4;


### PR DESCRIPTION
We are currently attempting to link both `-lfftw3f_omp` and `-lfftw3_threads`.  The former library isn't the correct precision (note the extra 'f', it's single-precision and we're calling double-precision FFTW functions).  If we remove the extra 'f', the two libraries are basically competing implementations and instead we should choose only one, so choose the OpenMP version to match the code.

https://www.fftw.org/fftw3_doc/Usage-of-Multi_002dthreaded-FFTW.html