### PR TITLE
Filesystem Hierarchy Standard improvements

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Build macOS app
         working-directory: Desktop_Interface
         run: |
-          GIT_HASH_SHORT=$(git rev-parse --short HEAD)
-          qmake CONFIG+=release PREFIX=/usr DEFINES+=GIT_HASH_SHORT=$GIT_HASH_SHORT
+          qmake CONFIG+=release
           make -j$(sysctl -n hw.ncpu)
           mkdir -p bin/Labrador.app/Contents/MacOS/Resources
           mkdir -p bin/Labrador.app/Contents/Frameworks

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,8 +58,7 @@ jobs:
         working-directory: Desktop_Interface
         shell: cmd
         run: |
-          for /f "delims=" %%i in ('git rev-parse --short HEAD') do set GIT_HASH_SHORT=%%i
-          qmake CONFIG+=release DEFINES+=GIT_HASH_SHORT=%GIT_HASH_SHORT% INCLUDEPATH+="C:\ProgramData\chocolatey\lib\eigen\include\eigen3"
+          qmake CONFIG+=release INCLUDEPATH+="C:\ProgramData\chocolatey\lib\eigen\include\eigen3"
           nmake
 
       # 6) Post-build steps: windeployqt, copy fftw DLL, etc.

--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -165,7 +165,7 @@ unix:!android:!macx{
         }
     }
 
-    target.path = /usr/bin/EspoTek-Labrador
+    target.path = /usr/bin
 
     firmware.path = /usr/share/EspoTek/Labrador/firmware
     firmware.files += $$files(bin/firmware/labrafirm*)
@@ -182,25 +182,14 @@ unix:!android:!macx{
     icon256.files += resources/icon256/espotek-labrador.png
     icon256.path = /usr/share/icons/hicolor/256x256/apps/
 
-    equals(APPIMAGE, 1){
-        desktop.files += resources/appimage/espotek-labrador.desktop
-    }
-    !equals(APPIMAGE, 1){
-        desktop.files += resources/espotek-labrador.desktop
-    }
+    desktop.files += resources/espotek-labrador.desktop
     desktop.path = /usr/share/applications
 
     symlink.path = /usr/bin
-    symlink.extra = ln -sf EspoTek-Labrador/Labrador ${INSTALL_ROOT}/usr/bin/labrador
+    symlink.extra = ln -sf Labrador $(INSTALL_ROOT)/usr/bin/labrador
 
     udevextra.path = /lib/udev/rules.d
     udevextra.extra = test -n $$shell_quote($(INSTALL_ROOT)) || { udevadm control --reload-rules && udevadm trigger --subsystem-match=usb ; }
-
-    equals(APPIMAGE, 1){
-        target.path = /usr/bin
-        firmware.path = /usr/bin/firmware
-        waveforms.path = /usr/bin/waveforms
-    }
 
     INSTALLS += target
     INSTALLS += lib_deploy
@@ -210,10 +199,7 @@ unix:!android:!macx{
     INSTALLS += icon48
     INSTALLS += icon256
     INSTALLS += desktop
-
-    !equals(APPIMAGE, 1){
-        INSTALLS += symlink
-    }
+    INSTALLS += symlink
     INSTALLS += udevextra
 }
 

--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -167,10 +167,10 @@ unix:!android:!macx{
 
     target.path = /usr/bin/EspoTek-Labrador
 
-    firmware.path = /usr/bin/EspoTek-Labrador/firmware
+    firmware.path = /usr/share/EspoTek/Labrador/firmware
     firmware.files += $$files(bin/firmware/labrafirm*)
 
-    waveforms.path = /usr/bin/EspoTek-Labrador/waveforms
+    waveforms.path = /usr/share/EspoTek/Labrador/waveforms
     waveforms.files += $$files(bin/waveforms/*)
 
     udev.path = /lib/udev/rules.d

--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -126,67 +126,66 @@ win32{
 ###########################################################
 
 unix:!android:!macx{
+    isEmpty(PREFIX): PREFIX = /usr/local
     INCLUDEPATH += $$PWD/build_linux
     CONFIG += link_pkgconfig
     PKGCONFIG += libusb-1.0  ##make sure you have the libusb-1.0-0-dev package!
     PKGCONFIG += fftw3       ##make sure you have the libfftw3-dev package!
     PKGCONFIG += eigen3      ##make sure you have the libeigen3-dev package!
     contains(QT_ARCH, arm) {
-            message("Building for Raspberry Pi")
-            #libdfuprog include
-            unix:!android:!macx:LIBS += -L$$PWD/build_linux/libdfuprog/lib/arm -ldfuprog-0.9
-            unix:!android:!macx:INCLUDEPATH += $$PWD/build_linux/libdfuprog/include
-            unix:!android:!macx:DEPENDPATH += $$PWD/build_linux/libdfuprog/include
-            QMAKE_CFLAGS += -fsigned-char
-            QMAKE_CXXFLAGS += -fsigned-char
-            DEFINES += "PLATFORM_RASPBERRY_PI"
-            #All ARM-Linux GCC treats char as unsigned by default???
-            lib_deploy.files = $$PWD/build_linux/libdfuprog/lib/arm/libdfuprog-0.9.so
-            lib_deploy.path = /usr/lib
+        message("Building for Raspberry Pi")
+        #libdfuprog include
+        LIBS += -L$$PWD/build_linux/libdfuprog/lib/arm -ldfuprog-0.9
+        INCLUDEPATH += $$PWD/build_linux/libdfuprog/include
+        DEPENDPATH += $$PWD/build_linux/libdfuprog/include
+        QMAKE_CFLAGS += -fsigned-char
+        QMAKE_CXXFLAGS += -fsigned-char
+        DEFINES += "PLATFORM_RASPBERRY_PI"
+        #All ARM-Linux GCC treats char as unsigned by default???
+        lib_deploy.files = $$PWD/build_linux/libdfuprog/lib/arm/libdfuprog-0.9.so
+        lib_deploy.path = $$PREFIX/lib
+
+    } else:contains(QT_ARCH, i386) {
+        message("Building for Linux (x86)")
+        #libdfuprog include
+        LIBS += -L$$PWD/build_linux/libdfuprog/lib/x86 -ldfuprog-0.9
+        INCLUDEPATH += $$PWD/build_linux/libdfuprog/include
+        DEPENDPATH += $$PWD/build_linux/libdfuprog/include
+        lib_deploy.files = $$PWD/build_linux/libdfuprog/lib/x86/libdfuprog-0.9.so
+        lib_deploy.path = $$PREFIX/lib
 
     } else {
-        contains(QT_ARCH, i386) {
-            message("Building for Linux (x86)")
-            #libdfuprog include
-            unix:!android:!macx:LIBS += -L$$PWD/build_linux/libdfuprog/lib/x86 -ldfuprog-0.9
-            unix:!android:!macx:INCLUDEPATH += $$PWD/build_linux/libdfuprog/include
-            unix:!android:!macx:DEPENDPATH += $$PWD/build_linux/libdfuprog/include
-            lib_deploy.files = $$PWD/build_linux/libdfuprog/lib/x86/libdfuprog-0.9.so
-            lib_deploy.path = /usr/lib
-
-        } else {
-            message("Building for Linux (x64)")
-            #libdfuprog include
-            unix:!android:!macx:LIBS += -L$$PWD/build_linux/libdfuprog/lib/x64 -ldfuprog-0.9
-            unix:!android:!macx:INCLUDEPATH += $$PWD/build_linux/libdfuprog/include
-            unix:!android:!macx:DEPENDPATH += $$PWD/build_linux/libdfuprog/include
-    	    lib_deploy.files = $$PWD/build_linux/libdfuprog/lib/x64/libdfuprog-0.9.so
-            lib_deploy.path = /usr/lib
-        }
+        message("Building for Linux (x64)")
+        #libdfuprog include
+        LIBS += -L$$PWD/build_linux/libdfuprog/lib/x64 -ldfuprog-0.9
+        INCLUDEPATH += $$PWD/build_linux/libdfuprog/include
+        DEPENDPATH += $$PWD/build_linux/libdfuprog/include
+        lib_deploy.files = $$PWD/build_linux/libdfuprog/lib/x64/libdfuprog-0.9.so
+        lib_deploy.path = $$PREFIX/lib
     }
 
-    target.path = /usr/bin
+    target.path = $$PREFIX/bin
 
-    firmware.path = /usr/share/EspoTek/Labrador/firmware
+    firmware.path = $$PREFIX/share/EspoTek/Labrador/firmware
     firmware.files += $$files(bin/firmware/labrafirm*)
 
-    waveforms.path = /usr/share/EspoTek/Labrador/waveforms
+    waveforms.path = $$PREFIX/share/EspoTek/Labrador/waveforms
     waveforms.files += $$files(bin/waveforms/*)
 
     udev.path = /lib/udev/rules.d
     udev.files = rules.d/69-labrador.rules
 
+    icon48.path = $$PREFIX/share/icons/hicolor/48x48/apps/
     icon48.files += resources/icon48/espotek-labrador.png
-    icon48.path = /usr/share/icons/hicolor/48x48/apps/
 
+    icon256.path = $$PREFIX/share/icons/hicolor/256x256/apps/
     icon256.files += resources/icon256/espotek-labrador.png
-    icon256.path = /usr/share/icons/hicolor/256x256/apps/
 
+    desktop.path = $$PREFIX/share/applications
     desktop.files += resources/espotek-labrador.desktop
-    desktop.path = /usr/share/applications
 
-    symlink.path = /usr/bin
-    symlink.extra = ln -sf Labrador $(INSTALL_ROOT)/usr/bin/labrador
+    symlink.path = $$PREFIX/bin
+    symlink.extra = ln -sf Labrador $(INSTALL_ROOT)$$PREFIX/bin/labrador
 
     udevextra.path = /lib/udev/rules.d
     udevextra.extra = test -n $$shell_quote($(INSTALL_ROOT)) || { udevadm control --reload-rules && udevadm trigger --subsystem-match=usb ; }

--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -18,6 +18,11 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets printsupport
 TARGET = Labrador
 TEMPLATE = app
 
+GIT_HASH_SHORT=$$system(git rev-parse --short HEAD)
+!isEmpty(GIT_HASH_SHORT) {
+    DEFINES += "GIT_HASH_SHORT=$${GIT_HASH_SHORT}"
+}
+
 QCP_VER = 1
 DEFINES += "QCP_VER=$${QCP_VER}"
 equals(QCP_VER,"2"){

--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -194,9 +194,7 @@ unix:!android:!macx{
     symlink.extra = ln -sf EspoTek-Labrador/Labrador ${INSTALL_ROOT}/usr/bin/labrador
 
     udevextra.path = /lib/udev/rules.d
-    !equals(DEB, 1){
-        udevextra.extra = udevadm control --reload-rules && udevadm trigger --subsystem-match=usb
-    }
+    udevextra.extra = test -n $$shell_quote($(INSTALL_ROOT)) || { udevadm control --reload-rules && udevadm trigger --subsystem-match=usb ; }
 
     equals(APPIMAGE, 1){
         target.path = /usr/bin
@@ -215,8 +213,8 @@ unix:!android:!macx{
 
     !equals(APPIMAGE, 1){
         INSTALLS += symlink
-        INSTALLS += udevextra
     }
+    INSTALLS += udevextra
 }
 
 

--- a/Desktop_Interface/functiongencontrol.cpp
+++ b/Desktop_Interface/functiongencontrol.cpp
@@ -1,5 +1,6 @@
 #include "functiongencontrol.h"
 #include "platformspecific.h"
+#include <QStandardPaths>
 
 namespace functionGen {
 
@@ -12,12 +13,13 @@ void SingleChannelController::waveformName(QString newName)
     qDebug() << "newName = " << newName;
     m_data.waveform = newName;
 
-#ifdef PLATFORM_ANDROID
-    QString path("assets:");
+#if defined(PLATFORM_ANDROID)
+    QFile file(newName.prepend("assets:/waveforms/").append(".tlw"));
+#elif defined(PLATFORM_LINUX)
+    QFile file(QStandardPaths::locate(QStandardPaths::AppDataLocation, newName.prepend("waveforms/").append(".tlw")));
 #else
-    QString path = QCoreApplication::applicationDirPath();
+    QFile file(QCoreApplication::applicationDirPath().append("/waveforms/").append(newName).append(".tlw"));
 #endif
-    QFile file(path.append("/waveforms/").append(newName).append(".tlw"));
 
     qDebug() << "opening" << file.fileName();
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -9,19 +9,17 @@
 #define DO_QUOTE(X) #X
 #define QUOTE(X) DO_QUOTE(X)
 
-#ifndef GIT_HASH_SHORT
-#define GIT_HASH_SHORT 0000000
-#endif
-
 namespace
 {
    constexpr uint32_t MAX_CONSOLE_BLOCK_COUNT = 512;
    constexpr char kDocumentationUrl[] = "https://github.com/espotek-org/Labrador/wiki";
    constexpr char kPinoutUrl[] = "https://github.com/espotek-org/Labrador/wiki/Pinout";
    constexpr char kAboutString[] = "<h4>EspoTek Labrador</h4>"
-                                   "Continuous Release<br>"\
-                                   "Git hash: <a href='https://github.com/espotek-org/Labrador/commits/" QUOTE(GIT_HASH_SHORT) "'>" QUOTE(GIT_HASH_SHORT) "</a><br>"\
-                                   "Website: <a href='http://espotek.com'>https://espotek.com</a><br>"\
+#ifdef GIT_HASH_SHORT
+                                   "Continuous Release<br>"
+                                   "Git hash: <a href='https://github.com/espotek-org/Labrador/commits/" QUOTE(GIT_HASH_SHORT) "'>" QUOTE(GIT_HASH_SHORT) "</a><br>"
+#endif
+                                   "Website: <a href='http://espotek.com'>https://espotek.com</a><br>"
                                    "Contact email: <a href='mailto:admin@espotek.com'>admin@espotek.com</a>";
    constexpr char kOrganisationName[] = "EspoTek";
    constexpr char kApplicationName[] = "Labrador";

--- a/Desktop_Interface/make_appimage
+++ b/Desktop_Interface/make_appimage
@@ -3,7 +3,7 @@
 set -e
 
 rm -rf AppDir
-qmake CONFIG+=release PREFIX=/usr DEFINES+=GIT_HASH_SHORT=$(git rev-parse --short HEAD)
+qmake CONFIG+=release PREFIX=/usr
 make -j$(nproc)
 make INSTALL_ROOT=AppDir install ; find AppDir/
 

--- a/Desktop_Interface/make_appimage
+++ b/Desktop_Interface/make_appimage
@@ -3,7 +3,7 @@
 set -e
 
 rm -rf AppDir
-qmake APPIMAGE=1 CONFIG+=release PREFIX=/usr DEFINES+=GIT_HASH_SHORT=$(git rev-parse --short HEAD)
+qmake CONFIG+=release PREFIX=/usr DEFINES+=GIT_HASH_SHORT=$(git rev-parse --short HEAD)
 make -j$(nproc)
 make INSTALL_ROOT=AppDir install ; find AppDir/
 

--- a/Desktop_Interface/make_deb
+++ b/Desktop_Interface/make_deb
@@ -2,7 +2,7 @@
 
 set -e
 
-qmake DEB=1 CONFIG+=release PREFIX=/usr DEFINES+=GIT_HASH_SHORT=$(git rev-parse --short HEAD)
+qmake CONFIG+=release PREFIX=/usr DEFINES+=GIT_HASH_SHORT=$(git rev-parse --short HEAD)
 make -j$(nproc)
 rm -rf deb
 make INSTALL_ROOT=deb install; find deb/

--- a/Desktop_Interface/make_deb
+++ b/Desktop_Interface/make_deb
@@ -2,7 +2,7 @@
 
 set -e
 
-qmake CONFIG+=release PREFIX=/usr DEFINES+=GIT_HASH_SHORT=$(git rev-parse --short HEAD)
+qmake CONFIG+=release PREFIX=/usr
 make -j$(nproc)
 rm -rf deb
 make INSTALL_ROOT=deb install; find deb/

--- a/Desktop_Interface/resources/AppRun
+++ b/Desktop_Interface/resources/AppRun
@@ -65,4 +65,6 @@ EOHelper
   rm "$HELPER"
 fi
 
+export XDG_DATA_DIRS="$HERE/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+
 exec "$HERE/usr/bin/Labrador" "$@"

--- a/Desktop_Interface/resources/appimage/espotek-labrador.desktop
+++ b/Desktop_Interface/resources/appimage/espotek-labrador.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Name=EspoTek Labrador
-Comment=Software Interface for Labrador Board
-Exec=Labrador 
-Terminal=false
-Type=Application
-Categories=Education;Electronics;
-Icon=espotek-labrador

--- a/Desktop_Interface/resources/espotek-labrador.desktop
+++ b/Desktop_Interface/resources/espotek-labrador.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=EspoTek Labrador
 Comment=Software Interface for Labrador Board
-Exec=/usr/bin/EspoTek-Labrador/Labrador 
+Exec=labrador
 Terminal=false
 Type=Application
 Categories=Education;Electronics;

--- a/Desktop_Interface/ui_elements/espocombobox.cpp
+++ b/Desktop_Interface/ui_elements/espocombobox.cpp
@@ -1,4 +1,5 @@
 #include "espocombobox.h"
+#include <QStandardPaths>
 
 espoComboBox::espoComboBox(QWidget *parent) : QComboBox(parent)
 {
@@ -7,12 +8,13 @@ espoComboBox::espoComboBox(QWidget *parent) : QComboBox(parent)
 
 void espoComboBox::readWaveformList(void)
 {
-#ifdef PLATFORM_ANDROID
-    QString path("assets:");
+#if defined(PLATFORM_ANDROID)
+    QFile file("assets:/waveforms/_list.wfl");
+#elif defined(PLATFORM_LINUX)
+    QFile file(QStandardPaths::locate(QStandardPaths::AppDataLocation, "waveforms/_list.wfl"));
 #else
-    QString path = QCoreApplication::applicationDirPath();
+    QFile file(QCoreApplication::applicationDirPath().append("/waveforms/_list.wfl"));
 #endif
-    QFile file(path.append("/waveforms/_list.wfl"));
 
     qDebug() << "opening" << file.fileName();
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))

--- a/Desktop_Interface/unixusbdriver.cpp
+++ b/Desktop_Interface/unixusbdriver.cpp
@@ -4,6 +4,7 @@
 #endif
 #include <QApplication>
 #include <QMessageBox>
+#include <QStandardPaths>
 
 unixUsbDriver::unixUsbDriver(QWidget *parent) : genericUsbDriver(parent)
 {
@@ -350,8 +351,13 @@ int unixUsbDriver::flashFirmware(void){
     qDebug() << "BA94 closed";
 
     //Get location of firmware file
+#if defined(PLATFORM_LINUX)
+    QString firmware_path = QString::asprintf("firmware/labrafirm_%04x_%02x.hex", EXPECTED_FIRMWARE_VERSION, DEFINED_EXPECTED_VARIANT);
+    firmware_path = QStandardPaths::locate(QStandardPaths::AppDataLocation, firmware_path);
+#else
     QString firmware_path = QCoreApplication::applicationDirPath();
     firmware_path.append(QString::asprintf("/firmware/labrafirm_%04x_%02x.hex", EXPECTED_FIRMWARE_VERSION, DEFINED_EXPECTED_VARIANT));
+#endif
     qDebug() << "FLASHING" << firmware_path;
 
     //Set up interface to dfuprog
@@ -406,8 +412,13 @@ int unixUsbDriver::flashFirmware(void){
 void unixUsbDriver::manualFirmwareRecovery(void){
 #ifndef PLATFORM_ANDROID
     //Get location of firmware file
+#if defined(PLATFORM_LINUX)
+    QString firmware_path = QString::asprintf("firmware/labrafirm_%04x_%02x.hex", EXPECTED_FIRMWARE_VERSION, DEFINED_EXPECTED_VARIANT);
+    firmware_path = QStandardPaths::locate(QStandardPaths::AppDataLocation, firmware_path);
+#else
     QString firmware_path = QCoreApplication::applicationDirPath();
     firmware_path.append(QString::asprintf("/firmware/labrafirm_%04x_%02x.hex", EXPECTED_FIRMWARE_VERSION, DEFINED_EXPECTED_VARIANT));
+#endif
 
     //Set up interface to dfuprog
     int exit_code;

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you're on Linux (including Raspberry Pi), then you can also build the softwar
 qmake
 make
 sudo make install
+sudo ldconfig
 ```
 Then, to launch, just type `labrador` into the terminal.
 

--- a/labrador_bootstrap_pi
+++ b/labrador_bootstrap_pi
@@ -37,6 +37,7 @@ cd labrador/Desktop_Interface
 qmake
 make
 sudo make install
+sudo ldconfig
 
 # Cleanup
 rm -rf labrador


### PR DESCRIPTION
This set of changes moves installed files to their customary location on Linux:  Binaries to `/usr/bin`, data files to a subdirectory of `/usr/share`.  This goal was a large part of #195 and will make it much easier to create a native package.

Additionally `PREFIX` on the `qmake` command line now works as intended (defaulting to `/usr/local`), and the need for `APPIMAGE=1`, `DEB=1`, and `GIT_HASH_SHORT=$(git rev-parse --short HEAD)` have all been removed.