### PR TITLE
Cursor update: instantiate new display controls for frequency [spectrum/response] windows

### DIFF
--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -297,7 +297,7 @@ void isoDriver::setVisible_CH2(bool visible){
 
 void isoDriver::setVoltageRange(QWheelEvent* event)
 {
-    if(doNotTouchGraph && !fileModeEnabled) return;
+    if((doNotTouchGraph && !fileModeEnabled) || spectrum || freqResp) return;
 
     bool isProperlyPaused = properlyPaused();
     double maxWindowSize = fileModeEnabled ? daq_maxWindowSize : ((double)MAX_WINDOW_SIZE);

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -96,6 +96,12 @@ public:
     bool spectrum = false;
     bool freqResp = false;
     espoSpinBox *freqValue_CH1 = NULL;
+    bool horiCursorEnabled0 = false; // TODO: move into DisplayControl
+    bool horiCursorEnabled1 = false; // TODO: move into DisplayControl
+    bool horiCursorEnabled2 = false; // TODO: move into DisplayControl
+    bool vertCursorEnabled0 = false; // TODO: move into DisplayControl
+    bool vertCursorEnabled1 = false; // TODO: move into DisplayControl
+    bool vertCursorEnabled2 = false; // TODO: move into DisplayControl
 private:
     //Those bloody bools that just Enable/Disable a single property
     bool paused_CH1 = false;
@@ -104,8 +110,6 @@ private:
     bool autoGainEnabled = true;
     bool placingHoriAxes = false; // TODO: move into DisplayControl
     bool placingVertAxes = false; // TODO: move into DisplayControl
-    bool horiCursorEnabled = false; // TODO: move into DisplayControl
-    bool vertCursorEnabled = false; // TODO: move into DisplayControl
     bool triggerEnabled = false;
     bool singleShotEnabled = false;
     bool multimeterShow = true;

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -80,7 +80,10 @@ public:
     int baudRate_CH2 = 9600;
     double currentVmean;
     //Display Control Vars (Variables that control how the buffers are displayed)
-    DisplayControl *display = new DisplayControl(-0.1, 0, 2.5, -0.5);
+    DisplayControl *display0 = new DisplayControl(-0.1, 0, 2.5, -0.5);
+    DisplayControl *display1 = new DisplayControl(0, 375000, 90, -60);
+    DisplayControl *display2 = new DisplayControl(0, 62500, 90, -90);
+    DisplayControl *display = display0;
     //Generic Functions
     void setDriver(genericUsbDriver *newDriver);
     void setAxes(QCustomPlot *newAxes);
@@ -150,13 +153,11 @@ private:
     float *readDataFile;
     char *isoTemp = NULL;
     short *isoTemp_short = NULL;
-    siprint *v0;
-    siprint *v1;
-    siprint *dv;
-    siprint *t0;
-    siprint *t1;
-    siprint *dt;
-    siprint *f;
+    siprint *v0, *v1, *dv;
+    siprint *db0, *db1, *ddb;
+    siprint *dbmv0, *dbmv1, *ddbmv;
+    siprint *t0, *t1, *dt, *f;
+    siprint *f0, *f1, *df;
     //Scope/MM++ related variables
     double currentVmax;
     double currentVmin;

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -30,15 +30,15 @@ class DisplayControl : public QObject
 {
     Q_OBJECT
 public:
-
+    explicit DisplayControl(double left, double right, double top, double bottom);
     double delay = 0;
-    double window = 0.01;
+    double window = 0;
     double y0 = 0;
     double y1 = 0;
     double x0 = 0;
     double x1 = 0;
-    double topRange = 2.5;
-    double botRange = -0.5;
+    double topRange = 0;
+    double botRange = 0;
 
     void setVoltageRange (QWheelEvent* event, bool isProperlyPaused, double maxWindowSize, QCustomPlot* axes);
 
@@ -80,7 +80,7 @@ public:
     int baudRate_CH2 = 9600;
     double currentVmean;
     //Display Control Vars (Variables that control how the buffers are displayed)
-    DisplayControl display;
+    DisplayControl *display = new DisplayControl(-0.1, 0, 2.5, -0.5);
     //Generic Functions
     void setDriver(genericUsbDriver *newDriver);
     void setAxes(QCustomPlot *newAxes);

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -1236,32 +1236,32 @@ void MainWindow::ctrlArrowDownTriggered(){
 
 void MainWindow::cycleDelayRight(){
     qDebug() << "RIGHT";
-    ui->controller_iso->display.delay -= ui->controller_iso->display.window/10;
-    if(ui->controller_iso->display.delay < 0) ui->controller_iso->display.delay = 0;
-    ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
+    ui->controller_iso->display->delay -= ui->controller_iso->display->window/10;
+    if(ui->controller_iso->display->delay < 0) ui->controller_iso->display->delay = 0;
+    ui->controller_iso->delayUpdated(ui->controller_iso->display->delay);
 }
 
 void MainWindow::cycleDelayLeft(){
     qDebug() << "LEFT";
     double mws = ui->controller_iso->fileModeEnabled ? ui->controller_iso->daq_maxWindowSize : ((double)MAX_WINDOW_SIZE);
-    ui->controller_iso->display.delay += ui->controller_iso->display.window/10;
-    if(ui->controller_iso->display.delay > (mws - ui->controller_iso->display.window)) ui->controller_iso->display.delay = (mws - ui->controller_iso->display.window);
-    ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
+    ui->controller_iso->display->delay += ui->controller_iso->display->window/10;
+    if(ui->controller_iso->display->delay > (mws - ui->controller_iso->display->window)) ui->controller_iso->display->delay = (mws - ui->controller_iso->display->window);
+    ui->controller_iso->delayUpdated(ui->controller_iso->display->delay);
 }
 
 void MainWindow::cycleDelayRight_large(){
     qDebug() << "RIGHT";
-    ui->controller_iso->display.delay -= ui->controller_iso->display.window/2;
-    if(ui->controller_iso->display.delay < 0) ui->controller_iso->display.delay = 0;
-    ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
+    ui->controller_iso->display->delay -= ui->controller_iso->display->window/2;
+    if(ui->controller_iso->display->delay < 0) ui->controller_iso->display->delay = 0;
+    ui->controller_iso->delayUpdated(ui->controller_iso->display->delay);
 }
 
 void MainWindow::cycleDelayLeft_large(){
     qDebug() << "LEFT";
     double mws = ui->controller_iso->fileModeEnabled ? ui->controller_iso->daq_maxWindowSize : ((double)MAX_WINDOW_SIZE);
-    ui->controller_iso->display.delay += ui->controller_iso->display.window/2;
-    if(ui->controller_iso->display.delay > (mws - ui->controller_iso->display.window)) ui->controller_iso->display.delay = (mws - ui->controller_iso->display.window);
-    ui->controller_iso->delayUpdated(ui->controller_iso->display.delay);
+    ui->controller_iso->display->delay += ui->controller_iso->display->window/2;
+    if(ui->controller_iso->display->delay > (mws - ui->controller_iso->display->window)) ui->controller_iso->display->delay = (mws - ui->controller_iso->display->window);
+    ui->controller_iso->delayUpdated(ui->controller_iso->display->delay);
 }
 
 void MainWindow::enableLabradorDebugging(bool enabled){
@@ -1344,27 +1344,27 @@ void MainWindow::on_actionSnap_to_Cursors_triggered()
 {
     double xLeft, xRight, yBot, yTop;
 
-    yTop = std::max(ui->controller_iso->display.y1, ui->controller_iso->display.y0);
-    yBot = std::min(ui->controller_iso->display.y1, ui->controller_iso->display.y0);
+    yTop = std::max(ui->controller_iso->display->y1, ui->controller_iso->display->y0);
+    yBot = std::min(ui->controller_iso->display->y1, ui->controller_iso->display->y0);
 
-    xRight = std::max(ui->controller_iso->display.x1, ui->controller_iso->display.x0);
-    xLeft = std::min(ui->controller_iso->display.x1, ui->controller_iso->display.x0);
+    xRight = std::max(ui->controller_iso->display->x1, ui->controller_iso->display->x0);
+    xLeft = std::min(ui->controller_iso->display->x1, ui->controller_iso->display->x0);
 
     if((yBot-yTop) != 0){
-        ui->controller_iso->display.topRange = yTop;
-        ui->controller_iso->display.botRange = yBot;
+        ui->controller_iso->display->topRange = yTop;
+        ui->controller_iso->display->botRange = yBot;
     }
 
     if((xLeft - xRight) != 0){
-        ui->controller_iso->display.delay = - xRight;
-        ui->controller_iso->display.window = xRight - xLeft;
+        ui->controller_iso->display->delay = - xRight;
+        ui->controller_iso->display->window = xRight - xLeft;
     }
 }
 
 void MainWindow::on_actionEnter_Manually_triggered()
 {
-    ui->controller_iso->display.delay = 0;
-    scopeRangeEnterDialog dialog(this, ui->controller_iso->display.topRange, ui->controller_iso->display.botRange, ui->controller_iso->display.window, ui->controller_iso->display.delay);
+    ui->controller_iso->display->delay = 0;
+    scopeRangeEnterDialog dialog(this, ui->controller_iso->display->topRange, ui->controller_iso->display->botRange, ui->controller_iso->display->window, ui->controller_iso->display->delay);
     dialog.setModal(true);
     connect(&dialog, SIGNAL(yTopUpdated(double)), ui->controller_iso, SLOT(setTopRange(double)));
     connect(&dialog, SIGNAL(yBotUpdated(double)), ui->controller_iso, SLOT(setBotRange(double)));
@@ -2471,7 +2471,7 @@ void MainWindow::on_actionShow_Range_Dialog_on_Main_Page_triggered(bool checked)
 #ifndef PLATFORM_ANDROID
     if (scopeRangeSwitch == nullptr)
     {
-        scopeRangeSwitch = new scopeRangeEnterDialog(nullptr, false, ui->controller_iso->display.topRange, ui->controller_iso->display.botRange, ui->controller_iso->display.window, ui->controller_iso->display.delay);
+        scopeRangeSwitch = new scopeRangeEnterDialog(nullptr, false, ui->controller_iso->display->topRange, ui->controller_iso->display->botRange, ui->controller_iso->display->window, ui->controller_iso->display->delay);
         scopeRangeSwitch->setWindowFlags(Qt::Widget);
         ui->verticalLayout_5->insertWidget(2, scopeRangeSwitch);
         connect(scopeRangeSwitch, SIGNAL(yTopUpdated(double)), ui->controller_iso, SLOT(setTopRange(double)));

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -2673,6 +2673,14 @@ void MainWindow::on_actionFrequency_Spectrum_triggered(bool checked)
     ui->scopeGroup_CH2->setDisabled(false);
     ui->controller_iso->display = checked ? ui->controller_iso->display1: ui->controller_iso->display0;
 
+    if(checked){
+        ui->cursorHoriCheck->setChecked(ui->controller_iso->horiCursorEnabled1);
+        ui->cursorVertCheck->setChecked(ui->controller_iso->vertCursorEnabled1);
+    }else{
+        ui->cursorHoriCheck->setChecked(ui->controller_iso->horiCursorEnabled0);
+        ui->cursorVertCheck->setChecked(ui->controller_iso->vertCursorEnabled0);
+    }
+
     if (checked == true)
         MAX_WINDOW_SIZE = 1<<17;
     else
@@ -2698,6 +2706,14 @@ void MainWindow::on_actionFrequency_Response_triggered(bool checked)
     ui->scopeGroup_CH2->setCheckable(!checked);
     ui->scopeGroup_CH2->setDisabled(checked);
     ui->controller_iso->display = checked ? ui->controller_iso->display2: ui->controller_iso->display0;
+
+    if(checked){
+        ui->cursorHoriCheck->setChecked(ui->controller_iso->horiCursorEnabled2);
+        ui->cursorVertCheck->setChecked(ui->controller_iso->vertCursorEnabled2);
+    }else{
+        ui->cursorHoriCheck->setChecked(ui->controller_iso->horiCursorEnabled0);
+        ui->cursorVertCheck->setChecked(ui->controller_iso->vertCursorEnabled0);
+    }
 }
 
 std::vector<uint8_t> MainWindow::uartEncode(const QString& text, UartParity parity)

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -2671,6 +2671,7 @@ void MainWindow::on_actionFrequency_Spectrum_triggered(bool checked)
         ui->actionFrequency_Response->setChecked(false);
     }
     ui->scopeGroup_CH2->setDisabled(false);
+    ui->controller_iso->display = checked ? ui->controller_iso->display1: ui->controller_iso->display0;
 
     if (checked == true)
         MAX_WINDOW_SIZE = 1<<17;
@@ -2696,6 +2697,7 @@ void MainWindow::on_actionFrequency_Response_triggered(bool checked)
     ui->scopeGroup_CH1->setCheckable(!checked);
     ui->scopeGroup_CH2->setCheckable(!checked);
     ui->scopeGroup_CH2->setDisabled(checked);
+    ui->controller_iso->display = checked ? ui->controller_iso->display2: ui->controller_iso->display0;
 }
 
 std::vector<uint8_t> MainWindow::uartEncode(const QString& text, UartParity parity)


### PR DESCRIPTION
So far the display controls were only available for the default voltage-time window.

![time_voltage](https://github.com/user-attachments/assets/12b44740-e0d8-4e71-ac6e-3f358a071935)

In this PR, we introduce new display controls for frequency spectrum and frequency response windows.

![frequency_spectrum](https://github.com/user-attachments/assets/c3357379-171b-467b-8ecf-e34c49c588a2)

![frequency_response](https://github.com/user-attachments/assets/037902cb-4826-4f89-8e57-6e806fce1be5)