### PR TITLE
siprint: Handle zero and other tiny magnitudes

### DIFF
--- a/Desktop_Interface/ui_elements/siprint.cpp
+++ b/Desktop_Interface/ui_elements/siprint.cpp
@@ -8,8 +8,8 @@ siprint::siprint(const char *unitsInit, double valInit)
 }
 
 char* siprint::printVal(){
-    std::string suffix;
     bool negative = (value < 0);
+    double abs_value = std::fabs(value);
 
     char* tempStringPtr = printString;
     if (negative)
@@ -18,41 +18,41 @@ char* siprint::printVal(){
         tempStringPtr++;
     }
 
-    if (std::fabs(value) >= 1000000000000000000)
+    if (abs_value >= 1000000000000000000)
     {
         sprintf(tempStringPtr, "Inf %s", units);
     }
-    else if (std::fabs(value) >= 1000000)
+    else if (abs_value >= 1000000)
     {
-        sprintf(tempStringPtr, "%.2fM%s", std::fabs(value)/1000000, units);
+        sprintf(tempStringPtr, "%.2fM%s", abs_value/1000000, units);
     }
-    else if (std::fabs(value) >= 1000)
+    else if (abs_value >= 1000)
     {
-        sprintf(tempStringPtr, "%.2fk%s",  std::fabs(value)/1000, units);
+        sprintf(tempStringPtr, "%.2fk%s", abs_value/1000, units);
     }
-    else if (std::fabs(value) >= 1)
+    else if (abs_value >= 1)
     {
-        sprintf(tempStringPtr, "%.2f%s",  std::fabs(value), units);
+        sprintf(tempStringPtr, "%.2f%s", abs_value, units);
     }
-    else if (std::fabs(value) >= 0.001)
+    else if (abs_value >= 0.001)
     {
-        sprintf(tempStringPtr, "%.2fm%s", std::fabs(value)*1000, units);
+        sprintf(tempStringPtr, "%.2fm%s", abs_value*1000, units);
     }
-    else if (std::fabs(value) >= 0.000001)
+    else if (abs_value >= 0.000001)
     {
-        sprintf(tempStringPtr, "%.2fu%s",  std::fabs(value)*1000000, units);
+        sprintf(tempStringPtr, "%.2fu%s", abs_value*1000000, units);
     }
-    else if (std::fabs(value) >= 0.000000001)
+    else if (abs_value >= 0.000000001)
     {
-        sprintf(tempStringPtr, "%.2fn%s",  std::fabs(value)*1000000000, units);
+        sprintf(tempStringPtr, "%.2fn%s", abs_value*1000000000, units);
     }
-    else if (std::fabs(value) >= 0.000000000001)
+    else if (abs_value >= 0.000000000001)
     {
-        sprintf(tempStringPtr, "%.2fp%s",  std::fabs(value)*1000000000000, units);
+        sprintf(tempStringPtr, "%.2fp%s", abs_value*1000000000000, units);
     }
-    else if (std::fabs(value) >= 1)
+    else
     {
-        sprintf(tempStringPtr, "%.2f%s",  std::fabs(value), units);
+        sprintf(tempStringPtr, "%.2f%s", abs_value, units);
     }
 
     return printString;


### PR DESCRIPTION
I discovered during testing #308 that if we use `siprint` to print 0 (or anything with magnitude < 10^-12), there is no branch arm for it.  As a result the string buffer will contain garbage and may not be nul-terminated.