### PR TITLE
Fix warnings in spectrum code

### DIFF
--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -92,7 +92,6 @@ QVector<double> AsyncDFT::getPowerSpectrum_dBmV(QVector<double> input, double wi
 
     /*Zero-padding for better resolution of DFT*/
     QVector<double> amplitude(n_samples/2+1,0);
-    maximum = -1;
 
     /*Executing FFTW plan*/
     fftw_execute(plan);
@@ -106,8 +105,6 @@ QVector<double> AsyncDFT::getPowerSpectrum_dBmV(QVector<double> input, double wi
     */
     for (int k = 0; k <= (n_samples+1)/2; ++k) {
          amplitude[k] = 60 + 10*std::log10(out_buffer[k][0]*out_buffer[k][0] + out_buffer[k][1]*out_buffer[k][1]) - 20*std::log10(wind_fact_sum);
-
-         maximum = (amplitude[k] > maximum ) ? amplitude[k] : maximum;
     }
 
     return amplitude;
@@ -135,23 +132,4 @@ std::unique_ptr<short[]> AsyncDFT::getWindow()
     }
 
     return readData;
-}
-
-QVector<double> AsyncDFT::normalizeDFT(double e_maximum, QVector<double> dft)
-{
-    double u_maximum;
-
-    /*Normalize with the greater maximum*/
-    if (this->maximum > e_maximum) {
-        u_maximum = this->maximum;
-    } else {
-        u_maximum = e_maximum;
-    }
-
-    for(int i=0; i < dft.size(); i++) {
-        dft[i] /= u_maximum;
-        dft[i] *= 100;
-    }
-
-    return dft;
 }

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -27,8 +27,6 @@ public:
     /*Return the window of samples*/
     std::unique_ptr<short[]> getWindow();
 
-    /*Normalize the DFT*/
-    QVector<double> normalizeDFT(double e_maximum, QVector<double> dft);
 private:
     /*Thread manager method*/
     void threadManager(); //threaded
@@ -36,9 +34,6 @@ private:
     /*Shifts left the window by 1*/
     void shift();
 
-public:
-    /*Maximum power value obtained from power spectrum*/
-    double maximum = -1;
 private:
     /*Time domain window*/
     std::list<double> window;

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -972,17 +972,8 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
                 else
                     f = internalBuffer375_CH1->async_dft->getFrequenciyWindow(internalBuffer375_CH1->m_samplesPerSecond);
 
-                /*Max amplitude for display purposes*/
-                double max1;
-                if(CH1_mode == -1)
-                    max1 = internalBuffer750->async_dft->maximum;
-                else
-                    max1 = internalBuffer375_CH1->async_dft->maximum;
-                double max2 = -1;
-
                 if(CH2_mode) {
                     QVector<double> amplitude2 = internalBuffer375_CH2->async_dft->getPowerSpectrum_dBmV(converted_dt_samples2, wind_fact_sum);
-                    max2 = internalBuffer375_CH2->async_dft->maximum;
                     axes->graph(1)->setData(f,amplitude2);
                 }
 

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -13,8 +13,8 @@
 #define PI_8 8*PI
 static constexpr int kSpectrumCounterMax = 4;
 
-#define HORICURSORENABLED ((~spectrum & ~freqResp & horiCursorEnabled0) | (spectrum & horiCursorEnabled1) | (freqResp & horiCursorEnabled2))
-#define VERTCURSORENABLED ((~spectrum & ~freqResp & vertCursorEnabled0) | (spectrum & vertCursorEnabled1) | (freqResp & vertCursorEnabled2))
+#define HORICURSORENABLED ((!spectrum & !freqResp & horiCursorEnabled0) | (spectrum & horiCursorEnabled1) | (freqResp & horiCursorEnabled2))
+#define VERTCURSORENABLED ((!spectrum & !freqResp & vertCursorEnabled0) | (spectrum & vertCursorEnabled1) | (freqResp & vertCursorEnabled2))
 
 isoDriver::isoDriver(QWidget *parent) : QLabel(parent)
 {


### PR DESCRIPTION
* Several different compilers complain about using the `~` operator on `bool`.  I believe it results in a bool-to-int conversion.
* There are also warnings about the `max1` and `max2` variables which are no longer used, and appear to be related to `normalizeDFT` which is also no longer used.  This removes both.