### PR TITLE
AsyncDFT cleanup

### DIFF
--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -18,6 +18,11 @@ AsyncDFT::~AsyncDFT()
 
 QVector<double> AsyncDFT::getPowerSpectrum_dBmV(QVector<double> input, double wind_fact_sum)
 {
+    /*Before doing anything, check if sliding DFT is computable*/
+    if (input.size() < n_samples) {
+        return QVector<double>();
+    }
+
     for(int i = 0; i < n_samples; i++) {
         in_buffer[i] = input[i];
     }

--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -5,11 +5,6 @@
 
 AsyncDFT::AsyncDFT()
 {
-    /*Data is not valid until we get n_samples into the window*/
-    data_valid = false;
-    /*Samples counter*/
-    samples_count=0;
-    /*Initializing time domain window to 0s*/
     /*FFTW3 inits*/
     fftw_init_threads();
     fftw_plan_with_nthreads(omp_get_max_threads() * 2);
@@ -23,31 +18,21 @@ AsyncDFT::~AsyncDFT()
 
 void AsyncDFT::addSample(short sample)
 {
-    /*Adding to the waiting jobs the sample*/
-    if (samples_count >= n_samples) {
-        /*Shifting window by 1 by removing first element and adding an element to the end*/
+    if (window.size() == n_samples) {
         window.pop_front();
-        window.push_back(sample);
-        samples_count = n_samples;
-        data_valid = true;
-    } else {
-        /*Fill the window*/
-        window.push_back(sample);
     }
-    /*Updating the number of samples*/
-    samples_count++;
+    window.push_back(sample);
 }
 
 void AsyncDFT::clearWindow()
 {
     window.clear();
-    samples_count = 0;
 }
 
 QVector<double> AsyncDFT::getPowerSpectrum_dBmV(QVector<double> input, double wind_fact_sum)
 {
     /*Before doing anything, check if sliding DFT is computable*/
-    if (data_valid == false) {
+    if (window.size() < n_samples) {
         throw std::exception();
     }
 

--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -75,7 +75,7 @@ QVector<double> AsyncDFT::getPowerSpectrum_dBmV(QVector<double> input, double wi
     return amplitude;
 }
 
-QVector<double> AsyncDFT::getFrequenciyWindow(int samplesPerSeconds)
+QVector<double> AsyncDFT::getFrequencyWindow(int samplesPerSeconds)
 {
     double delta_freq = ((double)  samplesPerSeconds)/ ((double) n_samples);
     QVector<double> f(n_samples/2 + 1);

--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -40,7 +40,7 @@ void AsyncDFT::clearWindow()
 QVector<double> AsyncDFT::getPowerSpectrum_dBmV(QVector<double> input, double wind_fact_sum)
 {
     /*Before doing anything, check if sliding DFT is computable*/
-    if (window.size() < n_samples) {
+    if (input.size() < n_samples) {
         throw std::exception();
     }
 
@@ -82,7 +82,7 @@ QVector<double> AsyncDFT::getFrequencyWindow(int samplesPerSeconds)
 
 QVector<short> AsyncDFT::getWindow()
 {
-    QVector<short> readData(n_samples);
+    QVector<short> readData(window.size());
     std::copy(window.begin(), window_iter, std::copy(window_iter, window.end(), readData.begin()));
     return readData;
 }

--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -1,13 +1,10 @@
 #include "asyncdft.h"
-#include <algorithm>
 #include <cmath>
 #include <omp.h>
 
 
 AsyncDFT::AsyncDFT()
 {
-    window.reserve(n_samples);
-    window_iter = window.begin();
     /*FFTW3 inits*/
     fftw_init_threads();
     fftw_plan_with_nthreads(omp_get_max_threads() * 2);
@@ -17,24 +14,6 @@ AsyncDFT::AsyncDFT()
 
 AsyncDFT::~AsyncDFT()
 {
-}
-
-void AsyncDFT::addSample(short sample)
-{
-    if (window.size() < n_samples) {
-        window.push_back(sample);
-    } else {
-        *window_iter++ = sample;
-        if (window_iter == window.end()) {
-            window_iter = window.begin();
-        }
-    }
-}
-
-void AsyncDFT::clearWindow()
-{
-    window.clear();
-    window_iter = window.begin();
 }
 
 QVector<double> AsyncDFT::getPowerSpectrum_dBmV(QVector<double> input, double wind_fact_sum)
@@ -73,11 +52,4 @@ QVector<double> AsyncDFT::getFrequencyWindow(int samplesPerSeconds)
     }
 
     return f;
-}
-
-QVector<short> AsyncDFT::getWindow()
-{
-    QVector<short> readData(window.size());
-    std::copy(window.begin(), window_iter, std::copy(window_iter, window.end(), readData.begin()));
-    return readData;
 }

--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -39,11 +39,6 @@ void AsyncDFT::clearWindow()
 
 QVector<double> AsyncDFT::getPowerSpectrum_dBmV(QVector<double> input, double wind_fact_sum)
 {
-    /*Before doing anything, check if sliding DFT is computable*/
-    if (input.size() < n_samples) {
-        throw std::exception();
-    }
-
     for(int i = 0; i < n_samples; i++) {
         in_buffer[i] = input[i];
     }

--- a/Desktop_Interface/asyncdft.cpp
+++ b/Desktop_Interface/asyncdft.cpp
@@ -1,15 +1,10 @@
 #include "asyncdft.h"
-#include <iostream>
-#include <math.h>
+#include <cmath>
 #include <omp.h>
-#include "isobuffer.h"
-#define DBG 0
 
 
 AsyncDFT::AsyncDFT()
 {
-    /*Creating the main thread, which will manage everything*/
-    stopping = false;
     /*Data is not valid until we get n_samples into the window*/
     data_valid = false;
     /*Samples counter*/
@@ -18,43 +13,13 @@ AsyncDFT::AsyncDFT()
     /*FFTW3 inits*/
     fftw_init_threads();
     fftw_plan_with_nthreads(omp_get_max_threads() * 2);
-#if DBG
-    std::cout << "Starting with " << omp_get_max_threads() << "threads" << std::endl;
-#endif
     out_buffer = fftw_alloc_complex(n_samples);
     plan = fftw_plan_dft_r2c_1d(n_samples,in_buffer, out_buffer,0);
 }
 
 AsyncDFT::~AsyncDFT()
 {
-#if DBG
-    stopping = true;
-    mtx_samples.unlock();   //Unlock thread manager if blocked and waiting for more samples
-    while (!manager.joinable());
-    manager.join();
-    std::cout << "Joined manager thread [DESTRUCTOR]" << std::endl;
-#endif
 }
-
-void AsyncDFT::threadManager()
-{
-    while(stopping == false) {
-        /*Calculating DFT if there are new samples, otherwise DFT would be the same*/
-        if (samples_count >= n_samples) {
-            mtx_samples.lock();
-            if (!window.empty()) {
-                window.pop_front();
-            }
-            short tmp = pending_samples.front();
-            pending_samples.pop();
-            window.push_back(tmp);
-            /*Data is now valid*/
-            data_valid = true;
-            mtx_samples.unlock();
-        }
-    }
-}
-
 
 void AsyncDFT::addSample(short sample)
 {

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -14,7 +14,7 @@ public:
 
     /* Raise exception if not ready yet*/
     QVector<double> getPowerSpectrum_dBmV(QVector<double> input, double wind_fact_sum);
-    QVector<double> getFrequenciyWindow(int samplesPerSeconds);
+    QVector<double> getFrequencyWindow(int samplesPerSeconds);
 
     /*Add a sample to the time domain samples*/
     void addSample(short sample);

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -13,19 +13,7 @@ public:
     QVector<double> getPowerSpectrum_dBmV(QVector<double> input, double wind_fact_sum);
     QVector<double> getFrequencyWindow(int samplesPerSeconds);
 
-    /*Add a sample to the time domain samples*/
-    void addSample(short sample);
-
-    /*Clear the window*/
-    void clearWindow();
-
-    /*Return the window of samples*/
-    QVector<short> getWindow();
-
 private:
-    /*Time domain window*/
-    QVector<short> window;
-    QVector<short>::iterator window_iter;
     double in_buffer[n_samples];
     /*FFTW3*/
     fftw_plan plan;

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -1,10 +1,8 @@
 #ifndef ASYNCDFT_H
 #define ASYNCDFT_H
-#include <thread>
 #include <QVector>
-#include <mutex>
-#include <queue>
 #include <list>
+#include <memory>
 #include <fftw3.h>
 
 class AsyncDFT
@@ -28,13 +26,6 @@ public:
     std::unique_ptr<short[]> getWindow();
 
 private:
-    /*Thread manager method*/
-    void threadManager(); //threaded
-
-    /*Shifts left the window by 1*/
-    void shift();
-
-private:
     /*Time domain window*/
     std::list<double> window;
     double in_buffer[n_samples];
@@ -45,10 +36,6 @@ private:
     /*FFTW3*/
     fftw_plan plan;
     fftw_complex *out_buffer;
-    std::mutex mtx_samples;
-    bool stopping = false;
-    std::thread manager;
-    std::queue<short> pending_samples;
 };
 
 #endif // ASYNCDFT_H

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -29,10 +29,6 @@ private:
     /*Time domain window*/
     std::list<double> window;
     double in_buffer[n_samples];
-    /*Indicates if dft is available*/
-    bool data_valid;
-    /*Number of time domain samples accumulated*/
-    int samples_count;
     /*FFTW3*/
     fftw_plan plan;
     fftw_complex *out_buffer;

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -10,7 +10,6 @@ public:
     ~AsyncDFT();
     static const int n_samples = 1<<17;
 
-    /* Raise exception if not ready yet*/
     QVector<double> getPowerSpectrum_dBmV(QVector<double> input, double wind_fact_sum);
     QVector<double> getFrequencyWindow(int samplesPerSeconds);
 

--- a/Desktop_Interface/asyncdft.h
+++ b/Desktop_Interface/asyncdft.h
@@ -1,8 +1,6 @@
 #ifndef ASYNCDFT_H
 #define ASYNCDFT_H
 #include <QVector>
-#include <list>
-#include <memory>
 #include <fftw3.h>
 
 class AsyncDFT
@@ -23,11 +21,12 @@ public:
     void clearWindow();
 
     /*Return the window of samples*/
-    std::unique_ptr<short[]> getWindow();
+    QVector<short> getWindow();
 
 private:
     /*Time domain window*/
-    std::list<double> window;
+    QVector<short> window;
+    QVector<short>::iterator window_iter;
     double in_buffer[n_samples];
     /*FFTW3*/
     fftw_plan plan;

--- a/Desktop_Interface/isobuffer.cpp
+++ b/Desktop_Interface/isobuffer.cpp
@@ -59,8 +59,7 @@ void isoBuffer::insertIntoBuffer(short item)
         m_back = 0;
     }
 
-    if (m_asyncDftActive)
-        async_dft->addSample(item);
+    async_dft->addSample(item);
 
     /* Fill-in freqResp buffer */
     if(m_freqRespActive)
@@ -196,17 +195,6 @@ void isoBuffer::gainBuffer(int gain_log)
             m_buffer[i+m_bufferLen] >>= gain_log;
         }
     }
-}
-
-void isoBuffer::enableDftWrite(bool enable)
-{
-    if ((enable == true) && (m_asyncDftActive == false))
-    {
-        delete async_dft;
-        async_dft = new AsyncDFT();
-    }
-
-    m_asyncDftActive = enable;
 }
 
 void isoBuffer::enableFreqResp(bool enable, double freqValue)

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -2,7 +2,9 @@
 #define ISOBUFFER_H
 
 // TODO: Move headers used only in implementation to isobuffer.cpp
+#include <list>
 #include <memory>
+#include <vector>
 
 #include <QWidget>
 #include <QString>
@@ -16,7 +18,6 @@
 #include "xmega.h"
 #include "desktop_settings.h"
 #include "genericusbdriver.h"
-#include "asyncdft.h"
 
 class isoDriver;
 class uartStyleDecoder;
@@ -48,7 +49,7 @@ class isoBuffer : public QWidget
 {
 	Q_OBJECT
 public:
-	isoBuffer(QWidget* parent = 0, int bufferLen = 0, isoDriver* caller = 0, unsigned char channel_value = 0);
+	isoBuffer(QWidget* parent = 0, int bufferLen = 0, int windowLen = 0, isoDriver* caller = 0, unsigned char channel_value = 0);
 	~isoBuffer() = default;
 
 //	Basic buffer operations
@@ -68,6 +69,7 @@ public:
 	void writeBuffer_short(short* data, int len);
 
 	std::unique_ptr<short[]> readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
+    std::vector<short> readWindow();
 //	file I/O
 private:
 	void outputSampleToFile(double averageSample);
@@ -107,6 +109,13 @@ public:
 	uint32_t m_insertedCount = 0;
 	uint32_t m_bufferLen;
 
+private:
+    // Time domain samples for spectrum view
+    std::vector<short> m_window;
+    std::vector<short>::size_type m_window_capacity;
+    std::vector<short>::iterator m_window_iter;
+
+public:
 	std::list<short> freqResp_buffer;
 	uint32_t freqResp_count = 0;
 	uint32_t freqResp_samples = 0;
@@ -124,8 +133,6 @@ public:
 //	UARTS decoding
 	uartStyleDecoder* m_decoder = NULL;
 	bool m_isDecoding = true;
-//DFT
-    AsyncDFT* async_dft;
 private:
 //	File I/O
 	bool m_fileIOEnabled = false;

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -57,7 +57,6 @@ public:
 	void clearBuffer();
 	void gainBuffer(int gain_log);
 
-	void enableDftWrite(bool enable);
 	void enableFreqResp(bool enable, double freqValue);
 
 // Advanced buffer operations
@@ -139,7 +138,6 @@ private:
 	unsigned int m_currentColumn = 0;
     uint32_t m_lastTriggerDetlaT = 0;
 
-	bool m_asyncDftActive = false;
 	bool m_freqRespActive = false;
 
 	isoDriver* m_virtualParent;

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -954,34 +954,39 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
         axes->yAxis->setRange(ymin, ymax);
     } else{
         if (spectrum) { /*If frequency spectrum mode*/
-            try {
-                /*Creating DFT amplitudes*/
-                QVector<double> amplitude1;
-                if(CH1_mode == -1)
-                    amplitude1 = internalBuffer750->async_dft->getPowerSpectrum_dBmV(converted_dt_samples1, wind_fact_sum);
-                else
-                    amplitude1 = internalBuffer375_CH1->async_dft->getPowerSpectrum_dBmV(converted_dt_samples1, wind_fact_sum);
-                /*Getting array of frequencies for display purposes*/
-                QVector<double> f;
-                if(CH1_mode == -1)
-                    f = internalBuffer750->async_dft->getFrequencyWindow(internalBuffer750->m_samplesPerSecond);
-                else
-                    f = internalBuffer375_CH1->async_dft->getFrequencyWindow(internalBuffer375_CH1->m_samplesPerSecond);
-
-                if(CH2_mode) {
-                    QVector<double> amplitude2 = internalBuffer375_CH2->async_dft->getPowerSpectrum_dBmV(converted_dt_samples2, wind_fact_sum);
-                    axes->graph(1)->setData(f,amplitude2);
-                }
-
-                axes->graph(0)->setData(f, amplitude1);
-                axes->xAxis->setLabel("Frequency (Hz)");
-                axes->yAxis->setLabel("Relative Power (dBmV)");
-                axes->xAxis->setRange(m_spectrumMinX, m_spectrumMaxX);
-                /*Setting maximum/minimum y-axis -60dBmV to 90dBmV*/
-                axes->yAxis->setRange(90,-60);
-            }  catch (std::exception) {
-                std::cout << "Cannot yet get correct value for DFT" << std::endl;
+            /*Getting array of frequencies for display purposes*/
+            QVector<double> f;
+            if (CH1_mode == -1) {
+                f = internalBuffer750->async_dft->getFrequencyWindow(internalBuffer750->m_samplesPerSecond);
+            } else {
+                f = internalBuffer375_CH1->async_dft->getFrequencyWindow(internalBuffer375_CH1->m_samplesPerSecond);
             }
+
+            /*Creating DFT amplitudes*/
+            if (CH1_mode == -1) {
+                if (converted_dt_samples1.size() == internalBuffer750->async_dft->n_samples) {
+                    auto amplitude = internalBuffer750->async_dft->getPowerSpectrum_dBmV(converted_dt_samples1, wind_fact_sum);
+                    axes->graph(0)->setData(f, amplitude);
+                }
+            } else {
+                if (converted_dt_samples1.size() == internalBuffer375_CH1->async_dft->n_samples) {
+                    auto amplitude = internalBuffer375_CH1->async_dft->getPowerSpectrum_dBmV(converted_dt_samples1, wind_fact_sum);
+                    axes->graph(0)->setData(f, amplitude);
+                }
+            }
+
+            if (CH2_mode) {
+                if (converted_dt_samples2.size() == internalBuffer375_CH2->async_dft->n_samples) {
+                    auto amplitude = internalBuffer375_CH2->async_dft->getPowerSpectrum_dBmV(converted_dt_samples2, wind_fact_sum);
+                    axes->graph(1)->setData(f, amplitude);
+                }
+            }
+
+            axes->xAxis->setLabel("Frequency (Hz)");
+            axes->yAxis->setLabel("Relative Power (dBmV)");
+            axes->xAxis->setRange(m_spectrumMinX, m_spectrumMaxX);
+            /*Setting maximum/minimum y-axis -60dBmV to 90dBmV*/
+            axes->yAxis->setRange(90, -60);
 
         } else if (freqResp){
             if(!paused_CH1)

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -968,9 +968,9 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
                 /*Getting array of frequencies for display purposes*/
                 QVector<double> f;
                 if(CH1_mode == -1)
-                    f = internalBuffer750->async_dft->getFrequenciyWindow(internalBuffer750->m_samplesPerSecond);
+                    f = internalBuffer750->async_dft->getFrequencyWindow(internalBuffer750->m_samplesPerSecond);
                 else
-                    f = internalBuffer375_CH1->async_dft->getFrequenciyWindow(internalBuffer375_CH1->m_samplesPerSecond);
+                    f = internalBuffer375_CH1->async_dft->getFrequencyWindow(internalBuffer375_CH1->m_samplesPerSecond);
 
                 if(CH2_mode) {
                     QVector<double> amplitude2 = internalBuffer375_CH2->async_dft->getPowerSpectrum_dBmV(converted_dt_samples2, wind_fact_sum);

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -726,10 +726,6 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
             return;
     }
 
-    internalBuffer375_CH1->enableDftWrite(spectrum);
-    internalBuffer375_CH2->enableDftWrite(spectrum);
-    internalBuffer750->enableDftWrite(spectrum);
-
     internalBuffer375_CH1->enableFreqResp(freqResp, freqValue_CH1->value());
     internalBuffer375_CH2->enableFreqResp(freqResp, freqValue_CH1->value());
 

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -941,11 +941,9 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
             auto f = m_asyncDFT->getFrequencyWindow(internalBuffer_CH1->m_samplesPerSecond);
 
             /*Creating DFT amplitudes*/
-            if (converted_dt_samples1.size() == m_asyncDFT->n_samples) {
-                auto amplitude = m_asyncDFT->getPowerSpectrum_dBmV(converted_dt_samples1, m_windowFactorsSum);
-                axes->graph(0)->setData(f, amplitude);
-            }
-            if (CH2_mode && converted_dt_samples2.size() == m_asyncDFT->n_samples) {
+            auto amplitude = m_asyncDFT->getPowerSpectrum_dBmV(converted_dt_samples1, m_windowFactorsSum);
+            axes->graph(0)->setData(f, amplitude);
+            if (CH2_mode) {
                 auto amplitude = m_asyncDFT->getPowerSpectrum_dBmV(converted_dt_samples2, m_windowFactorsSum);
                 axes->graph(1)->setData(f, amplitude);
             }

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -819,11 +819,8 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
         else
             dt_samples1  = internalBuffer375_CH1->async_dft->getWindow();
         dt_samples2  = internalBuffer375_CH2->async_dft->getWindow();
-        if(CH1_mode == -1)
-            converted_dt_samples1.resize(internalBuffer750->async_dft->n_samples);
-        else
-            converted_dt_samples1.resize(internalBuffer375_CH1->async_dft->n_samples);
-        converted_dt_samples2.resize(internalBuffer375_CH2->async_dft->n_samples);
+        converted_dt_samples1.resize(dt_samples1.size());
+        converted_dt_samples2.resize(dt_samples2.size());
     }
     else if (freqResp)
     {

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -808,8 +808,7 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
         }
     }
     /*Convert data also for spectrum CH1 and CH2*/
-    std::unique_ptr<short[]> dt_samples1;
-    std::unique_ptr<short[]> dt_samples2;
+    QVector<short> dt_samples1, dt_samples2;
     QVector<double> converted_dt_samples1, converted_dt_samples2;
     QVector<double> x(GRAPH_SAMPLES), CH1(GRAPH_SAMPLES), CH2(GRAPH_SAMPLES);
 
@@ -843,7 +842,7 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
 
         if (spectrum)
         {
-            analogConvert(dt_samples1.get(), &converted_dt_samples1, 128, AC_CH1, 1);
+            analogConvert(dt_samples1.data(), &converted_dt_samples1, 128, AC_CH1, 1);
             for (int i=0; i < converted_dt_samples1.size(); i++)
             {
                 converted_dt_samples1[i] /= m_attenuation_CH1;
@@ -883,7 +882,7 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
 
         if (spectrum)
         {
-            analogConvert(dt_samples2.get(), &converted_dt_samples2, 128, AC_CH2, 2);
+            analogConvert(dt_samples2.data(), &converted_dt_samples2, 128, AC_CH2, 2);
             for (int i=0; i < converted_dt_samples2.size(); i++)
             {
                 converted_dt_samples2[i] /= m_attenuation_CH1;
@@ -920,7 +919,7 @@ void isoDriver::frameActionGeneric(char CH1_mode, char CH2_mode)
 
         if (spectrum)
         {
-            analogConvert(dt_samples1.get(), &converted_dt_samples1, 128, AC_CH1, 1);
+            analogConvert(dt_samples1.data(), &converted_dt_samples1, 128, AC_CH1, 1);
             for (int i=0; i < converted_dt_samples1.size(); i++)
             {
                 converted_dt_samples1[i] /= m_attenuation_CH1;

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -13,6 +13,7 @@
 #include "uartstyledecoder.h"
 #include "espospinbox.h"
 
+class AsyncDFT;
 class isoBuffer;
 class isoBuffer_file;
 
@@ -198,6 +199,7 @@ private:
     //DAQ
     double daqLoad_startTime, daqLoad_endTime;
     //Spectrum
+    AsyncDFT *m_asyncDFT;
     double m_spectrumMinX = 0;
     double m_spectrumMaxX = 375000;
     int m_windowingType = 0;

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -203,6 +203,8 @@ private:
     double m_spectrumMinX = 0;
     double m_spectrumMaxX = 375000;
     int m_windowingType = 0;
+    QVector<double> m_windowFactors;
+    double m_windowFactorsSum;
     //Frequency response
     QVector<double> m_freqRespFreq;
     QVector<double> m_freqRespGain;


### PR DESCRIPTION
Here are a few refactorings of the spectrum code.  I'm working on making the spectrum code optional (for Android, which doesn't have the libraries nor the UI set up yet to use it).

* Remove the unused `AsyncDFT::threadManager` method.  I suppose nothing in the `AsyncDFT` class is actually asynchronous anymore.
* Incoming samples were being placed in a ring buffer inside the `AsyncDFT` class.  When it's time to run an FFT, we extract the samples from the class, modify them (`isoDriver::analogConvert` and subsequent code), then pass them back to the class for the FFT.  I've moved the ring buffer to the `isoBuffer` class, alongside all the other buffers, and now `AsyncDFT` only contains the FFT code.  Additionally I've changed the ring buffer to use `std::vector<short>` instead of `std::list<double>` since it's more memory efficient.
* Change it so that all samples are placed in the ring buffer, even when spectrum mode isn't active.  This makes the program more responsive when switching between o-scope and spectrum mode since it doesn't need to wait on the ring buffer to fill.  Also check the length of the buffer independently for CH1 and CH2.
* Compute the windowing function coefficients only when changing the window.  This also fixes a bug where the windowing function would be integrated twice when CH2 is enabled.