### PR TITLE
Fix Android build

### DIFF
--- a/Desktop_Interface/Labrador.pro
+++ b/Desktop_Interface/Labrador.pro
@@ -218,9 +218,9 @@ unix:SOURCES += unixusbdriver.cpp
 unix:HEADERS += unixusbdriver.h
 
 # For multithreading on Unix fftw
-unix:!macx: LIBS += -fopenmp
+unix:!android:!macx: LIBS += -fopenmp
 macx: LIBS += -lomp
-unix: LIBS += -lfftw3_omp
+unix:!android: LIBS += -lfftw3_omp
 
 #############################################################
 ########       SHARED ANDROID/LINUX GCC FLAGS      #########
@@ -282,6 +282,11 @@ android {
     #liblog include
     LIBS += -L$$PWD/build_android/liblog/lib -llog
     ANDROID_EXTRA_LIBS += $${PWD}/build_android/liblog/lib/liblog.so
+
+    # Frequency spectrum/response disabled for now, needs UI and supporting libraries
+    DEFINES += DISABLE_SPECTRUM
+    SOURCES -= asyncdft.cpp
+    HEADERS -= asyncdft.h
 
     # Library dependencies are only compiled for this ABI currently
     ANDROID_ABIS = armeabi-v7a

--- a/Desktop_Interface/isobuffer.h
+++ b/Desktop_Interface/isobuffer.h
@@ -49,7 +49,11 @@ class isoBuffer : public QWidget
 {
 	Q_OBJECT
 public:
+#ifndef DISABLE_SPECTRUM
 	isoBuffer(QWidget* parent = 0, int bufferLen = 0, int windowLen = 0, isoDriver* caller = 0, unsigned char channel_value = 0);
+#else
+	isoBuffer(QWidget* parent = 0, int bufferLen = 0, isoDriver* caller = 0, unsigned char channel_value = 0);
+#endif
 	~isoBuffer() = default;
 
 //	Basic buffer operations
@@ -58,7 +62,9 @@ public:
 	void clearBuffer();
 	void gainBuffer(int gain_log);
 
-	void enableFreqResp(bool enable, double freqValue);
+#ifndef DISABLE_SPECTRUM
+    void enableFreqResp(bool enable, double freqValue);
+#endif
 
 // Advanced buffer operations
 private:
@@ -69,7 +75,9 @@ public:
 	void writeBuffer_short(short* data, int len);
 
     std::vector<short> readBuffer(double sampleWindow, int numSamples, bool singleBit, double delayOffset);
+#ifndef DISABLE_SPECTRUM
     std::vector<short> readWindow();
+#endif
 //	file I/O
 private:
 	void outputSampleToFile(double averageSample);
@@ -109,16 +117,19 @@ public:
 	uint32_t m_insertedCount = 0;
 	uint32_t m_bufferLen;
 
+#ifndef DISABLE_SPECTRUM
 private:
     // Time domain samples for spectrum view
     std::vector<short> m_window;
     std::vector<short>::size_type m_window_capacity;
     std::vector<short>::iterator m_window_iter;
 
+    bool m_freqRespActive = false;
 public:
-	std::list<short> freqResp_buffer;
-	uint32_t freqResp_count = 0;
-	uint32_t freqResp_samples = 0;
+    std::list<short> freqResp_buffer;
+    uint32_t freqResp_count = 0;
+    uint32_t freqResp_samples = 0;
+#endif
 
 // Conversion And Sampling
 	double m_voltage_ref = 1.65;
@@ -144,8 +155,6 @@ private:
 	qulonglong m_fileIO_numBytesWritten;
 	unsigned int m_currentColumn = 0;
     uint32_t m_lastTriggerDetlaT = 0;
-
-	bool m_freqRespActive = false;
 
 	isoDriver* m_virtualParent;
 

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -1,3 +1,7 @@
+#ifndef DISABLE_SPECTRUM
+#include <Eigen/Dense>  // First so that our #defines won't conflict
+#endif
+
 #include "isodriver.h"
 #include "isobuffer.h"
 #include "isobuffer_file.h"
@@ -7,7 +11,6 @@
 
 #ifndef DISABLE_SPECTRUM
 #include "asyncdft.h"
-#include <Eigen/Dense>
 
 #define PI 3.141592653589793  // Predefined value for pi
 #define PI_2 2*PI

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -94,15 +94,21 @@ public:
     //DAQ
     bool fileModeEnabled = false;
     double daq_maxWindowSize;
+#ifndef DISABLE_SPECTRUM
     bool spectrum = false;
     bool freqResp = false;
     espoSpinBox *freqValue_CH1 = NULL;
+#endif
     bool horiCursorEnabled0 = false; // TODO: move into DisplayControl
+#ifndef DISABLE_SPECTRUM
     bool horiCursorEnabled1 = false; // TODO: move into DisplayControl
     bool horiCursorEnabled2 = false; // TODO: move into DisplayControl
+#endif
     bool vertCursorEnabled0 = false; // TODO: move into DisplayControl
+#ifndef DISABLE_SPECTRUM
     bool vertCursorEnabled1 = false; // TODO: move into DisplayControl
     bool vertCursorEnabled2 = false; // TODO: move into DisplayControl
+#endif
 private:
     //Those bloody bools that just Enable/Disable a single property
     bool paused_CH1 = false;
@@ -142,7 +148,9 @@ private:
     QVector<double> analogConvert(std::vector<short> &in, int TOP, bool AC, int channel);
     QVector<double> digitalConvert(std::vector<short> &in);
     QVector<double> fileStreamConvert(float *in);
+#ifndef DISABLE_SPECTRUM
     double windowing_factor(int m_windowingType, int n_samples, int index);
+#endif
     bool properlyPaused();
     void udateCursors(void);
     short reverseFrontEnd(double voltage);
@@ -194,6 +202,7 @@ private:
     uint8_t deviceMode_prev;
     //DAQ
     double daqLoad_startTime, daqLoad_endTime;
+#ifndef DISABLE_SPECTRUM
     //Spectrum
     AsyncDFT *m_asyncDFT;
     double m_spectrumMinX = 0;
@@ -210,6 +219,7 @@ private:
     double m_freqRespStep = 100;
     int m_freqRespType = 0;
     bool m_freqRespFlag = false;
+#endif
 
 signals:
     void setGain(double newGain);
@@ -307,6 +317,7 @@ public slots:
     void attenuationChanged_CH2(int attenuationIndex);
     void setHexDisplay_CH1(bool enabled);
     void setHexDisplay_CH2(bool enabled);
+#ifndef DISABLE_SPECTRUM
     void setMinSpectrum(double minSpectrum);
     void setMaxSpectrum(double maxSpectrum);
     void setWindowingType(int windowing);
@@ -315,6 +326,7 @@ public slots:
     void setFreqRespStep(double stepFreqResp);
     void setFreqRespType(int typeFreqResp);
     void restartFreqResp();
+#endif
 };
 
 #endif // ISODRIVER_H

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -65,8 +65,10 @@ MainWindow::MainWindow(QWidget *parent) :
 #endif
     ui->controller_iso->setAxes(ui->scopeAxes);
 
+#ifndef DISABLE_SPECTRUM
     ui->controller_iso->freqValue_CH1 = ui->frequencyValue_CH1;
     connect(ui->frequencyValue_CH1, SIGNAL(valueChanged(double)), this, SLOT(display(double)));
+#endif
 
     ui->timeBaseSlider->setMaximum(10*log10(MAX_WINDOW_SIZE));
 
@@ -266,6 +268,7 @@ MainWindow::MainWindow(QWidget *parent) :
 #endif
     connect(ui->controller_iso, &isoDriver::enableCursorGroup, this, &MainWindow::cursorGroupEnabled);
 
+#ifndef DISABLE_SPECTRUM
     // Frequency spectrum
     spectrumMinXSpinbox = new espoSpinBox();
     spectrumMaxXSpinbox = new espoSpinBox();
@@ -389,6 +392,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->verticalLayout->addWidget(freqRespLayout2Widget);
     freqRespLayout1Widget->setVisible(false);
     freqRespLayout2Widget->setVisible(false);
+#endif
 }
 
 MainWindow::~MainWindow()
@@ -2674,6 +2678,7 @@ void MainWindow::on_actionShow_Debug_Console_triggered(bool checked)
     enableLabradorDebugging(checked);
 }
 
+#ifndef DISABLE_SPECTRUM
 void MainWindow::on_actionFrequency_Spectrum_triggered(bool checked)
 {
     ui->controller_iso->spectrum = checked;
@@ -2737,6 +2742,7 @@ void MainWindow::on_actionFrequency_Response_triggered(bool checked)
         ui->cursorVertCheck->setChecked(ui->controller_iso->vertCursorEnabled0);
     }
 }
+#endif
 
 std::vector<uint8_t> MainWindow::uartEncode(const QString& text, UartParity parity)
 {

--- a/Desktop_Interface/mainwindow.h
+++ b/Desktop_Interface/mainwindow.h
@@ -225,8 +225,10 @@ private slots:
     void on_actionDark_Mode_triggered(bool checked);
 
     void on_actionShow_Debug_Console_triggered(bool checked);
+#ifndef DISABLE_SPECTRUM
     void on_actionFrequency_Spectrum_triggered(bool checked);
     void on_actionFrequency_Response_triggered(bool checked);
+#endif
 
     void on_serialEncodingCheck_CH1_toggled(bool checked);
     void on_txuart_textChanged();
@@ -303,6 +305,7 @@ private:
     QShortcut *shortcut_Debug;
     QShortcut *shortcut_Esc;
 
+#ifndef DISABLE_SPECTRUM
     // Frequency spectrum
     QWidget* spectrumLayoutWidget = nullptr;
     espoSpinBox* spectrumMinXSpinbox = nullptr;
@@ -317,6 +320,7 @@ private:
     espoSpinBox* freqRespStepSpinbox = nullptr;
     QComboBox* freqRespTypeComboBox = nullptr;
     QPushButton *freqRespRestartButton = nullptr;
+#endif
 
     //Duct Tape
     bool dt_AlreadyAskedAboutCalibration = false;

--- a/Desktop_Interface/ui_files_mobile/mainwindow.ui
+++ b/Desktop_Interface/ui_files_mobile/mainwindow.ui
@@ -1507,6 +1507,19 @@
          </widget>
         </item>
         <item>
+         <widget class="QPlainTextEdit" name="txuart">
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="verticalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOff</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QPlainTextEdit" name="console2">
           <property name="minimumSize">
            <size>
@@ -1589,6 +1602,13 @@
                  </widget>
                 </item>
                </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="serialEncodingCheck_CH1">
+               <property name="text">
+                <string>Serial Encoding</string>
+               </property>
               </widget>
              </item>
             </layout>
@@ -4355,6 +4375,30 @@
      <y>432</y>
     </hint>
    </hints>
+  </connection>
+  <connection>
+   <sender>serialEncodingCheck_CH1</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>txuart</receiver>
+   <slot>setVisible(bool)</slot>
+  </connection>
+  <connection>
+   <sender>serialEncodingCheck_CH1</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>waveformSelect_CH1</receiver>
+   <slot>setDisabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>serialEncodingCheck_CH1</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>frequencyValue_CH1</receiver>
+   <slot>setDisabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>serialEncodingCheck_CH1</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>dcOffsetValue_CH1</receiver>
+   <slot>setDisabled(bool)</slot>
   </connection>
  </connections>
  <slots>


### PR DESCRIPTION
1. Disable everything spectrum-related, since the mobile UI isn't set up for it yet, and since we don't have the fftw/eigen dependencies set up for it either.  Accomplished mostly by wrapping those parts of the code with `#ifndef DISABLE_SPECTRUM` / `#endif`, which is all meant to be temporary until it's properly supported.
2. Add the serial encoding widgets to the mobile UI, since there is code that references the `txuart` and `serialEncodingCheck_CH1` widgets.

These two changes are enough to get the code to build.  I don't know how stable or usable it is, as compared to our current Android release.