### PR TITLE
Improvements to cursor measurement display

### DIFF
--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -636,8 +636,8 @@ void isoDriver::updateCursors(){
 #endif
     if (!cursorStatsEnabled) return;
 
-    char temp_hori[64];
-    char temp_vert[64];
+    QString temp_hori;
+    QString temp_vert;
 #ifndef DISABLE_SPECTRUM
     if(spectrum)
     {
@@ -647,8 +647,8 @@ void isoDriver::updateCursors(){
         f0->value = display->x0;
         f1->value = display->x1;
         df->value = fabs(display->x0 - display->x1);
-        snprintf(temp_hori, sizeof temp_hori, "P0 = %s, P1 = %s, ΔP = %s", dbmv0->printVal(), dbmv1->printVal(), ddbmv->printVal());
-        snprintf(temp_vert, sizeof temp_vert, "f0 = %s, f1 = %s, Δf = %s", f0->printVal(), f1->printVal(), df->printVal());
+        temp_hori = QString::asprintf("P0 = %s, P1 = %s, ΔP = %s", dbmv0->printVal(), dbmv1->printVal(), ddbmv->printVal());
+        temp_vert = QString::asprintf("f0 = %s, f1 = %s, Δf = %s", f0->printVal(), f1->printVal(), df->printVal());
     }
     else if(freqResp)
     {
@@ -658,8 +658,8 @@ void isoDriver::updateCursors(){
         f0->value = display->x0;
         f1->value = display->x1;
         df->value = fabs(display->x0 - display->x1);
-        snprintf(temp_hori, sizeof temp_hori, "P0 = %s, P1 = %s, ΔP = %s", db0->printVal(), db1->printVal(), ddb->printVal());
-        snprintf(temp_vert, sizeof temp_vert, "f0 = %s, f1 = %s, Δf = %s", f0->printVal(), f1->printVal(), df->printVal());
+        temp_hori = QString::asprintf("P0 = %s, P1 = %s, ΔP = %s", db0->printVal(), db1->printVal(), ddb->printVal());
+        temp_vert = QString::asprintf("f0 = %s, f1 = %s, Δf = %s", f0->printVal(), f1->printVal(), df->printVal());
     }
     else
 #endif
@@ -671,8 +671,8 @@ void isoDriver::updateCursors(){
         t1->value = display->x1;
         dt->value = fabs(display->x0 - display->x1);
         f->value = 1 / (display->x1 - display->x0);
-        snprintf(temp_hori, sizeof temp_hori, "V0 = %s, V1 = %s, ΔV = %s", v0->printVal(), v1->printVal(), dv->printVal());
-        snprintf(temp_vert, sizeof temp_vert, "t0 = %s, t1 = %s, Δt = %s, f = %s", t0->printVal(), t1->printVal(), dt->printVal(), f->printVal());
+        temp_hori = QString::asprintf("V0 = %s, V1 = %s, ΔV = %s", v0->printVal(), v1->printVal(), dv->printVal());
+        temp_vert = QString::asprintf("t0 = %s, t1 = %s, Δt = %s, f = %s", t0->printVal(), t1->printVal(), dt->printVal(), f->printVal());
     }
 
     QString cursorStatsString;

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -647,8 +647,8 @@ void isoDriver::updateCursors(){
         f0->value = display->x0;
         f1->value = display->x1;
         df->value = std::fabs(display->x1 - display->x0);
-        temp_hori = QString::asprintf("P0: %s\nP1: %s\nΔP: %s", dbmv0->printVal(), dbmv1->printVal(), ddbmv->printVal());
-        temp_vert = QString::asprintf("f0: %s\nf1: %s\nΔf: %s", f0->printVal(), f1->printVal(), df->printVal());
+        temp_hori = QString::asprintf("P0:%11s\nP1:%11s\nΔP:%11s", dbmv0->printVal(), dbmv1->printVal(), ddbmv->printVal());
+        temp_vert = QString::asprintf("f0:%11s\nf1:%11s\nΔf:%11s", f0->printVal(), f1->printVal(), df->printVal());
     }
     else if(freqResp)
     {
@@ -658,8 +658,8 @@ void isoDriver::updateCursors(){
         f0->value = display->x0;
         f1->value = display->x1;
         df->value = std::fabs(display->x1 - display->x0);
-        temp_hori = QString::asprintf("P0: %s\nP1: %s\nΔP: %s", db0->printVal(), db1->printVal(), ddb->printVal());
-        temp_vert = QString::asprintf("f0: %s\nf1: %s\nΔf: %s", f0->printVal(), f1->printVal(), df->printVal());
+        temp_hori = QString::asprintf("P0:%9s\nP1:%9s\nΔP:%9s", db0->printVal(), db1->printVal(), ddb->printVal());
+        temp_vert = QString::asprintf("f0:%9s\nf1:%9s\nΔf:%9s", f0->printVal(), f1->printVal(), df->printVal());
     }
     else
 #endif
@@ -671,8 +671,8 @@ void isoDriver::updateCursors(){
         t1->value = display->x1;
         dt->value = std::fabs(display->x1 - display->x0);
         f->value = 1.0 / dt->value;
-        temp_hori = QString::asprintf("V0: %s\nV1: %s\nΔV: %s", v0->printVal(), v1->printVal(), dv->printVal());
-        temp_vert = QString::asprintf("t0: %s\nt1: %s\nΔt: %s\nf: %s", t0->printVal(), t1->printVal(), dt->printVal(), f->printVal());
+        temp_hori = QString::asprintf("V0:%8s\nV1:%8s\nΔV:%8s", v0->printVal(), v1->printVal(), dv->printVal());
+        temp_vert = QString::asprintf("t0:%8s\nt1:%8s\nΔt:%8s\nf:%8s", t0->printVal(), t1->printVal(), dt->printVal(), f->printVal());
     }
 
     QString cursorStatsString;

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -586,7 +586,7 @@ void isoDriver::cursorEnableVert(bool enabled){
 void isoDriver::updateCursors(){
     if(!(VERTCURSORENABLED || HORICURSORENABLED)){
 #if QCP_VER == 1
-        cursorTextPtr->setVisible(0);
+        cursorLabel->setVisible(0);
 #endif
         return;
     }
@@ -632,7 +632,7 @@ void isoDriver::updateCursors(){
         axes->graph(5)->setData(hori1x, hori1y);
     }
 #if QCP_VER == 1
-    cursorTextPtr->setVisible(cursorStatsEnabled);
+    cursorLabel->setVisible(cursorStatsEnabled);
 #endif
     if (!cursorStatsEnabled) return;
 
@@ -680,7 +680,7 @@ void isoDriver::updateCursors(){
     if (HORICURSORENABLED && VERTCURSORENABLED) cursorStatsString.append("\n");
     if (VERTCURSORENABLED) cursorStatsString.append(temp_vert);
 #if QCP_VER == 1
-    cursorTextPtr->setText(cursorStatsString);
+    cursorLabel->setText(cursorStatsString);
 #endif
 }
 

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -636,8 +636,6 @@ void isoDriver::updateCursors(){
 #endif
     if (!cursorStatsEnabled) return;
 
-    QString *cursorStatsString = new QString();
-
     char temp_hori[64];
     char temp_vert[64];
 #ifndef DISABLE_SPECTRUM
@@ -677,14 +675,13 @@ void isoDriver::updateCursors(){
         snprintf(temp_vert, sizeof temp_vert, "t0 = %s, t1 = %s, Δt = %s, f = %s", t0->printVal(), t1->printVal(), dt->printVal(), f->printVal());
     }
 
-    if(HORICURSORENABLED) cursorStatsString->append(temp_hori);
-    if(HORICURSORENABLED && VERTCURSORENABLED) cursorStatsString->append("\n");
-    if(VERTCURSORENABLED) cursorStatsString->append(temp_vert);
-    //qDebug() << temp;
+    QString cursorStatsString;
+    if (HORICURSORENABLED) cursorStatsString.append(temp_hori);
+    if (HORICURSORENABLED && VERTCURSORENABLED) cursorStatsString.append("\n");
+    if (VERTCURSORENABLED) cursorStatsString.append(temp_vert);
 #if QCP_VER == 1
-    cursorTextPtr->setText(*(cursorStatsString));
+    cursorTextPtr->setText(cursorStatsString);
 #endif
-    delete cursorStatsString;
 }
 
 short isoDriver::reverseFrontEnd(double voltage){

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -643,10 +643,10 @@ void isoDriver::updateCursors(){
     {
         dbmv0->value = display->y0;
         dbmv1->value = display->y1;
-        ddbmv->value = display->y0-display->y1;
+        ddbmv->value = std::fabs(display->y1 - display->y0);
         f0->value = display->x0;
         f1->value = display->x1;
-        df->value = fabs(display->x0 - display->x1);
+        df->value = std::fabs(display->x1 - display->x0);
         temp_hori = QString::asprintf("P0 = %s, P1 = %s, ΔP = %s", dbmv0->printVal(), dbmv1->printVal(), ddbmv->printVal());
         temp_vert = QString::asprintf("f0 = %s, f1 = %s, Δf = %s", f0->printVal(), f1->printVal(), df->printVal());
     }
@@ -654,10 +654,10 @@ void isoDriver::updateCursors(){
     {
         db0->value = display->y0;
         db1->value = display->y1;
-        ddb->value = display->y0-display->y1;
+        ddb->value = std::fabs(display->y1 - display->y0);
         f0->value = display->x0;
         f1->value = display->x1;
-        df->value = fabs(display->x0 - display->x1);
+        df->value = std::fabs(display->x1 - display->x0);
         temp_hori = QString::asprintf("P0 = %s, P1 = %s, ΔP = %s", db0->printVal(), db1->printVal(), ddb->printVal());
         temp_vert = QString::asprintf("f0 = %s, f1 = %s, Δf = %s", f0->printVal(), f1->printVal(), df->printVal());
     }
@@ -666,11 +666,11 @@ void isoDriver::updateCursors(){
     {
         v0->value = display->y0;
         v1->value = display->y1;
-        dv->value = display->y0-display->y1;
+        dv->value = std::fabs(display->y1 - display->y0);
         t0->value = display->x0;
         t1->value = display->x1;
-        dt->value = fabs(display->x0 - display->x1);
-        f->value = 1 / (display->x1 - display->x0);
+        dt->value = std::fabs(display->x1 - display->x0);
+        f->value = 1.0 / dt->value;
         temp_hori = QString::asprintf("V0 = %s, V1 = %s, ΔV = %s", v0->printVal(), v1->printVal(), dv->printVal());
         temp_vert = QString::asprintf("t0 = %s, t1 = %s, Δt = %s, f = %s", t0->printVal(), t1->printVal(), dt->printVal(), f->printVal());
     }

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -647,8 +647,8 @@ void isoDriver::updateCursors(){
         f0->value = display->x0;
         f1->value = display->x1;
         df->value = std::fabs(display->x1 - display->x0);
-        temp_hori = QString::asprintf("P0 = %s, P1 = %s, ΔP = %s", dbmv0->printVal(), dbmv1->printVal(), ddbmv->printVal());
-        temp_vert = QString::asprintf("f0 = %s, f1 = %s, Δf = %s", f0->printVal(), f1->printVal(), df->printVal());
+        temp_hori = QString::asprintf("P0: %s\nP1: %s\nΔP: %s", dbmv0->printVal(), dbmv1->printVal(), ddbmv->printVal());
+        temp_vert = QString::asprintf("f0: %s\nf1: %s\nΔf: %s", f0->printVal(), f1->printVal(), df->printVal());
     }
     else if(freqResp)
     {
@@ -658,8 +658,8 @@ void isoDriver::updateCursors(){
         f0->value = display->x0;
         f1->value = display->x1;
         df->value = std::fabs(display->x1 - display->x0);
-        temp_hori = QString::asprintf("P0 = %s, P1 = %s, ΔP = %s", db0->printVal(), db1->printVal(), ddb->printVal());
-        temp_vert = QString::asprintf("f0 = %s, f1 = %s, Δf = %s", f0->printVal(), f1->printVal(), df->printVal());
+        temp_hori = QString::asprintf("P0: %s\nP1: %s\nΔP: %s", db0->printVal(), db1->printVal(), ddb->printVal());
+        temp_vert = QString::asprintf("f0: %s\nf1: %s\nΔf: %s", f0->printVal(), f1->printVal(), df->printVal());
     }
     else
 #endif
@@ -671,8 +671,8 @@ void isoDriver::updateCursors(){
         t1->value = display->x1;
         dt->value = std::fabs(display->x1 - display->x0);
         f->value = 1.0 / dt->value;
-        temp_hori = QString::asprintf("V0 = %s, V1 = %s, ΔV = %s", v0->printVal(), v1->printVal(), dv->printVal());
-        temp_vert = QString::asprintf("t0 = %s, t1 = %s, Δt = %s, f = %s", t0->printVal(), t1->printVal(), dt->printVal(), f->printVal());
+        temp_hori = QString::asprintf("V0: %s\nV1: %s\nΔV: %s", v0->printVal(), v1->printVal(), dv->printVal());
+        temp_vert = QString::asprintf("t0: %s\nt1: %s\nΔt: %s\nf: %s", t0->printVal(), t1->printVal(), dt->printVal(), f->printVal());
     }
 
     QString cursorStatsString;

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -62,7 +62,7 @@ public:
     isoBuffer *internalBuffer750;
     isoBuffer_file *internalBufferFile = NULL;
 #if QCP_VER == 1
-    QCPItemText *cursorTextPtr;
+    QCPItemText *cursorLabel;
     QCPItemText *triggerFrequencyLabel;
 #endif
     genericUsbDriver *driver;

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -416,7 +416,7 @@ void MainWindow::initialisePlot()
     textLabel->position->setCoords(0.99, 0); // place position at center/top of axis rect
     textLabel->setTextAlignment(Qt::AlignTop|Qt::AlignRight);
     textLabel->setText("Cursor Label Here");
-    textLabel->setFont(QFont("Courier New", 16));
+    textLabel->setFont(QFont("Monospace", 12));
     textLabel->setColor(Qt::white);
     textLabel->setPen(QPen(Qt::white));
     textLabel->setBrush(QBrush(Qt::black));
@@ -427,7 +427,7 @@ void MainWindow::initialisePlot()
     triggerFrequencyLabel->position->setType(QCPItemPosition::ptAxisRectRatio);
     triggerFrequencyLabel->position->setCoords(0.5, 0.98);
     triggerFrequencyLabel->setText("Default Trigger Frequency Text");
-    triggerFrequencyLabel->setFont(QFont("Courier New", 16));
+    triggerFrequencyLabel->setFont(QFont("Monospace", 12));
     triggerFrequencyLabel->setColor(Qt::white);
     triggerFrequencyLabel->setPen(QPen(Qt::white));
     triggerFrequencyLabel->setBrush(QBrush(Qt::black));

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -414,6 +414,7 @@ void MainWindow::initialisePlot()
     textLabel->setPositionAlignment(Qt::AlignTop|Qt::AlignRight);
     textLabel->position->setType(QCPItemPosition::ptAxisRectRatio);
     textLabel->position->setCoords(0.99, 0); // place position at center/top of axis rect
+    textLabel->setTextAlignment(Qt::AlignTop|Qt::AlignRight);
     textLabel->setText("Cursor Label Here");
     textLabel->setFont(QFont("Courier New", 16));
     textLabel->setColor(Qt::white);

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -409,6 +409,9 @@ void MainWindow::initialisePlot()
     ui->scopeAxes->addGraph();
 
 #if QCP_VER == 1
+    QFont labelFont("Monospace", 12);
+    labelFont.setStyleHint(QFont::Monospace);
+
     auto cursorLabel = new QCPItemText(ui->scopeAxes);
     ui->scopeAxes->addItem(cursorLabel);
     cursorLabel->setPositionAlignment(Qt::AlignTop|Qt::AlignRight);
@@ -416,7 +419,7 @@ void MainWindow::initialisePlot()
     cursorLabel->position->setCoords(0.99, 0); // place position at center/top of axis rect
     cursorLabel->setTextAlignment(Qt::AlignTop|Qt::AlignRight);
     cursorLabel->setText("Cursor Label Here");
-    cursorLabel->setFont(QFont("Monospace", 12));
+    cursorLabel->setFont(labelFont);
     cursorLabel->setColor(Qt::white);
     cursorLabel->setPen(QPen(Qt::white));
     cursorLabel->setBrush(QBrush(Qt::black));
@@ -427,7 +430,7 @@ void MainWindow::initialisePlot()
     triggerFrequencyLabel->position->setType(QCPItemPosition::ptAxisRectRatio);
     triggerFrequencyLabel->position->setCoords(0.5, 0.98);
     triggerFrequencyLabel->setText("Default Trigger Frequency Text");
-    triggerFrequencyLabel->setFont(QFont("Monospace", 12));
+    triggerFrequencyLabel->setFont(labelFont);
     triggerFrequencyLabel->setColor(Qt::white);
     triggerFrequencyLabel->setPen(QPen(Qt::white));
     triggerFrequencyLabel->setBrush(QBrush(Qt::black));

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -453,23 +453,24 @@ void MainWindow::initialisePlot()
     ui->scopeAxes->yAxis->setTicker(yTicker);
 #endif
 
-    QPen *dashPen = new QPen(Qt::white, 2);
-    dashPen->setStyle(Qt::DashLine);
+    QPen axisPen(Qt::white, 1);
+    QPen cursorSolidPen(Qt::white, 2);
+    QPen cursorDashPen(Qt::white, 2);
+    cursorDashPen.setStyle(Qt::DashLine);
 
     ui->scopeAxes->graph(0)->setPen(QPen(Qt::yellow, 1));
     ui->scopeAxes->graph(1)->setPen(QPen(Qt::cyan, 1));
-    ui->scopeAxes->graph(2)->setPen(QPen(Qt::white, 2));
-    ui->scopeAxes->graph(3)->setPen(*(dashPen));
-    ui->scopeAxes->graph(4)->setPen(QPen(Qt::white, 2));
-    ui->scopeAxes->graph(5)->setPen(*(dashPen));
+    ui->scopeAxes->graph(2)->setPen(cursorSolidPen);
+    ui->scopeAxes->graph(3)->setPen(cursorDashPen);
+    ui->scopeAxes->graph(4)->setPen(cursorSolidPen);
+    ui->scopeAxes->graph(5)->setPen(cursorDashPen);
 
-
-    ui->scopeAxes->xAxis->setBasePen(QPen(Qt::white, 1));
-    ui->scopeAxes->yAxis->setBasePen(QPen(Qt::white, 1));
-    ui->scopeAxes->xAxis->setTickPen(QPen(Qt::white, 1));
-    ui->scopeAxes->yAxis->setTickPen(QPen(Qt::white, 1));
-    ui->scopeAxes->xAxis->setSubTickPen(QPen(Qt::white, 1));
-    ui->scopeAxes->yAxis->setSubTickPen(QPen(Qt::white, 1));
+    ui->scopeAxes->xAxis->setBasePen(axisPen);
+    ui->scopeAxes->yAxis->setBasePen(axisPen);
+    ui->scopeAxes->xAxis->setTickPen(axisPen);
+    ui->scopeAxes->yAxis->setTickPen(axisPen);
+    ui->scopeAxes->xAxis->setSubTickPen(axisPen);
+    ui->scopeAxes->yAxis->setSubTickPen(axisPen);
     ui->scopeAxes->xAxis->setTickLength(6);
     ui->scopeAxes->yAxis->setTickLength(6);
     ui->scopeAxes->xAxis->setSubTickLength(4);

--- a/Desktop_Interface/mainwindow.cpp
+++ b/Desktop_Interface/mainwindow.cpp
@@ -398,7 +398,7 @@ MainWindow::~MainWindow()
 
 void MainWindow::initialisePlot()
 {
-    QCPCurve *xyCurve = new QCPCurve(ui->scopeAxes->xAxis, ui->scopeAxes->yAxis);
+    auto xyCurve = new QCPCurve(ui->scopeAxes->xAxis, ui->scopeAxes->yAxis);
     xyCurve->setPen(QPen(Qt::yellow, 1));
     ui->scopeAxes->addPlottable(xyCurve);
     ui->scopeAxes->addGraph();
@@ -409,19 +409,19 @@ void MainWindow::initialisePlot()
     ui->scopeAxes->addGraph();
 
 #if QCP_VER == 1
-    textLabel = new QCPItemText(ui->scopeAxes);
-    ui->scopeAxes->addItem(textLabel);
-    textLabel->setPositionAlignment(Qt::AlignTop|Qt::AlignRight);
-    textLabel->position->setType(QCPItemPosition::ptAxisRectRatio);
-    textLabel->position->setCoords(0.99, 0); // place position at center/top of axis rect
-    textLabel->setTextAlignment(Qt::AlignTop|Qt::AlignRight);
-    textLabel->setText("Cursor Label Here");
-    textLabel->setFont(QFont("Monospace", 12));
-    textLabel->setColor(Qt::white);
-    textLabel->setPen(QPen(Qt::white));
-    textLabel->setBrush(QBrush(Qt::black));
+    auto cursorLabel = new QCPItemText(ui->scopeAxes);
+    ui->scopeAxes->addItem(cursorLabel);
+    cursorLabel->setPositionAlignment(Qt::AlignTop|Qt::AlignRight);
+    cursorLabel->position->setType(QCPItemPosition::ptAxisRectRatio);
+    cursorLabel->position->setCoords(0.99, 0); // place position at center/top of axis rect
+    cursorLabel->setTextAlignment(Qt::AlignTop|Qt::AlignRight);
+    cursorLabel->setText("Cursor Label Here");
+    cursorLabel->setFont(QFont("Monospace", 12));
+    cursorLabel->setColor(Qt::white);
+    cursorLabel->setPen(QPen(Qt::white));
+    cursorLabel->setBrush(QBrush(Qt::black));
 
-    QCPItemText* triggerFrequencyLabel = new QCPItemText(ui->scopeAxes);
+    auto triggerFrequencyLabel = new QCPItemText(ui->scopeAxes);
     ui->scopeAxes->addItem(triggerFrequencyLabel);
     triggerFrequencyLabel->setPositionAlignment(Qt::AlignBottom|Qt::AlignHCenter);
     triggerFrequencyLabel->position->setType(QCPItemPosition::ptAxisRectRatio);
@@ -433,9 +433,9 @@ void MainWindow::initialisePlot()
     triggerFrequencyLabel->setBrush(QBrush(Qt::black));
 
 
-    textLabel->setVisible(false);
+    cursorLabel->setVisible(false);
     triggerFrequencyLabel->setVisible(false);
-    ui->controller_iso->cursorTextPtr = textLabel;
+    ui->controller_iso->cursorLabel = cursorLabel;
     ui->controller_iso->triggerFrequencyLabel = triggerFrequencyLabel;
 
     ui->scopeAxes->yAxis->setAutoTickCount(9);

--- a/Desktop_Interface/mainwindow.h
+++ b/Desktop_Interface/mainwindow.h
@@ -237,7 +237,6 @@ private:
     Ui::MainWindow *ui;
     QWheelEvent *wheelEmu;
     bool forceSquare = false;
-    QCPItemText *textLabel;
     QFile *output375_CH1, *output375_CH2, *output750;
     unsigned char caibrateStage;
     QMessageBox *calibrationMessages;

--- a/Desktop_Interface/ui_elements/siprint.cpp
+++ b/Desktop_Interface/ui_elements/siprint.cpp
@@ -15,21 +15,21 @@ char* siprint::printVal(){
     if (abs_value >= 1000000000000000000.0) {
         snprintf(printString, sizeof printString, "%sInf %s", sign, units);
     } else if (abs_value >= 1000000.0) {
-        snprintf(printString, sizeof printString, "%s%.2fM%s", sign, abs_value/1000000, units);
+        snprintf(printString, sizeof printString, "%s%.4gM%s", sign, abs_value/1000000, units);
     } else if (abs_value >= 1000.0) {
-        snprintf(printString, sizeof printString, "%s%.2fk%s", sign, abs_value/1000, units);
+        snprintf(printString, sizeof printString, "%s%.4gk%s", sign, abs_value/1000, units);
     } else if (abs_value >= 1.0) {
-        snprintf(printString, sizeof printString, "%s%.2f%s", sign, abs_value, units);
+        snprintf(printString, sizeof printString, "%s%.4g%s", sign, abs_value, units);
     } else if (abs_value >= 0.001) {
-        snprintf(printString, sizeof printString, "%s%.2fm%s", sign, abs_value*1000, units);
+        snprintf(printString, sizeof printString, "%s%.4gm%s", sign, abs_value*1000, units);
     } else if (abs_value >= 0.000001) {
-        snprintf(printString, sizeof printString, "%s%.2fu%s", sign, abs_value*1000000, units);
+        snprintf(printString, sizeof printString, "%s%.4gu%s", sign, abs_value*1000000, units);
     } else if (abs_value >= 0.000000001) {
-        snprintf(printString, sizeof printString, "%s%.2fn%s", sign, abs_value*1000000000, units);
+        snprintf(printString, sizeof printString, "%s%.4gn%s", sign, abs_value*1000000000, units);
     } else if (abs_value >= 0.000000000001) {
-        snprintf(printString, sizeof printString, "%s%.2fp%s", sign, abs_value*1000000000000, units);
+        snprintf(printString, sizeof printString, "%s%.4gp%s", sign, abs_value*1000000000000, units);
     } else {
-        snprintf(printString, sizeof printString, "%s%.2f%s", sign, abs_value, units);
+        snprintf(printString, sizeof printString, "%s%.4g%s", sign, abs_value, units);
     }
 
     return printString;


### PR DESCRIPTION
The string containing the cursor measurements tends to be too long to fit inside the plot window, and the left side gets cut off.  I've added some line breaks, right-alignment, and made the font a bit smaller so that now the measurements fit nicely in the top right corner.  Plus some other code cleanup.
![Screenshot at 2025-06-02 23-15-36](https://github.com/user-attachments/assets/84b2b219-d64d-41a2-adfb-a1d89a0fa5c3)
