### PR TITLE
Update Windows workflow to use Windows 2022

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +79,7 @@ jobs:
   build-installer:
     needs:
       - build-windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,6 +39,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.platform }}
+          toolset: 14.2
 
       - name: Build librador
         if: matrix.platform == 'x64'

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ Librador_API/___librador/librademo/librademo
 
 Librador_API/___librador/basicdemo/Makefile*
 Librador_API/___librador/basicdemo/basicdemo
+
+Labrador.app
+.DS_Store


### PR DESCRIPTION
Update Windows workflow from the unsupported windows-2019 to the new windows-2022.