### PR TITLE
New disable spectrum guards

### DIFF
--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -348,6 +348,10 @@ DisplayControl::DisplayControl(double left, double right, double top, double bot
     rightRange = right;
 }
 
+<<<<<<< HEAD
+=======
+#ifndef DISABLE_SPECTRUM
+>>>>>>> freq_resp_and_spec_zoom
 void DisplayControl::setRespAndSpecRanges(QWheelEvent* event, QCustomPlot* axes, isoDriver* driver)
 {
     double steps = event->delta() / 120.0;
@@ -416,6 +420,10 @@ void DisplayControl::setRespAndSpecRanges(QWheelEvent* event, QCustomPlot* axes,
         
     }
   }
+<<<<<<< HEAD
+=======
+#endif
+>>>>>>> freq_resp_and_spec_zoom
 
 
 

--- a/Desktop_Interface/isodriver.cpp
+++ b/Desktop_Interface/isodriver.cpp
@@ -348,10 +348,7 @@ DisplayControl::DisplayControl(double left, double right, double top, double bot
     rightRange = right;
 }
 
-<<<<<<< HEAD
-=======
 #ifndef DISABLE_SPECTRUM
->>>>>>> freq_resp_and_spec_zoom
 void DisplayControl::setRespAndSpecRanges(QWheelEvent* event, QCustomPlot* axes, isoDriver* driver)
 {
     double steps = event->delta() / 120.0;
@@ -420,10 +417,7 @@ void DisplayControl::setRespAndSpecRanges(QWheelEvent* event, QCustomPlot* axes,
         
     }
   }
-<<<<<<< HEAD
-=======
 #endif
->>>>>>> freq_resp_and_spec_zoom
 
 
 

--- a/Desktop_Interface/isodriver.h
+++ b/Desktop_Interface/isodriver.h
@@ -45,7 +45,9 @@ public:
     bool logSpaceX = false;
 
     void setVoltageRange (QWheelEvent* event, bool isProperlyPaused, double maxWindowSize, QCustomPlot* axes);
+#ifndef DISABLE_SPECTRUM
     void setRespAndSpecRanges (QWheelEvent* event, QCustomPlot* axes, isoDriver* driver);
+#endif
 
 signals:
     void topRangeUpdated(double);


### PR DESCRIPTION
Added DISABLE_SPECTRUM guards to the declaration and definition of DisplayControl:setRespAndSpecRanges  .  These allow the program to compile when DISABLE_SPECTRUM is active (i.e., for Android builds)