### PR TITLE
'scope firmware DMA settings edits

### DIFF
--- a/AVR_Code/USB_BULK_TEST/src/tiny_dma.c
+++ b/AVR_Code/USB_BULK_TEST/src/tiny_dma.c
@@ -284,7 +284,7 @@ void tiny_dma_set_mode_2(void){
 	DMA.CH3.DESTADDR2 = 0x00;
 	
 	//Must enable last for REPCNT won't work!
-	DMA.CH3.CTRLA |= DMA_CH_ENABLE_bm;  //Enable!
+// 	DMA.CH3.CTRLA |= DMA_CH_ENABLE_bm;  //Enable!
 	
 	DMA.CH0.CTRLA = 0x00;
 	DMA.CH0.CTRLA = DMA_CH_RESET_bm;
@@ -307,7 +307,7 @@ void tiny_dma_set_mode_2(void){
 	DMA.CH1.CTRLA = DMA_STANDARD_CTRLA;
 	DMA.CH1.CTRLB = DMA_STANDARD_INTERRUPT;
 	DMA.CH1.ADDRCTRL = DMA_CH_SRCRELOAD_BURST_gc | DMA_CH_SRCDIR_INC_gc | DMA_CH_DESTDIR_INC_gc | DMA_CH_DESTRELOAD_BLOCK_gc;   //Source reloads after each burst, with byte incrementing.  Dest does not reload, but does increment address.
-	DMA.CH1.TRIGSRC = DMA_CH_TRIGSRC_ADCA_CH0_gc;	//Triggered from ADCA channel 0
+	DMA.CH1.TRIGSRC = DMA_CH_TRIGSRC_ADCA_CH2_gc;	//Triggered from ADCA channel 2
 	DMA.CH1.TRFCNT = DMA_STANDARD_TRANSFER_LENGTH;
 				
 	DMA.CH1.SRCADDR0 = (( (uint16_t) &ADCA.CH2.RESL) >> 0) & 0xFF; //Source address is ADC


### PR DESCRIPTION
These edits to the DMA settings in the firmware might improve the performance of #367 at frequencies above 25 khz, but it's not obvious that they do.
Changes like those to line 17,
`DMA.CH0.ADDRCTRL = DMA_CH_SRCRELOAD_BURST_gc | DMA_CH_SRCDIR_INC_gc | DMA_CH_DESTDIR_INC_gc | DMA_CH_DESTRELOAD_BLOCK_gc;   //Source reloads after each burst, with byte incrementing.  Dest does not reload, but does increment address.`
->
`DMA.CH0.ADDRCTRL = DMA_CH_SRCDIR_FIXED_gc | DMA_CH_DESTDIR_INC_gc | DMA_CH_DESTRELOAD_BLOCK_gc;   //Source reloads after each burst, with byte incrementing.  Dest does not reload, but does increment address.`
may just be a matter of taste, but it seems possible that the second method takes fewer steps.  From what I can tell, these transfers are both 1 byte per burst and 1 byte per transfer, so 1 transfer per burst.  If `DMA_CH_SRCRELOAD_BURST_gc | DMA_CH_SRCDIR_INC_gc` is set, the source address gets incremented after a transfer, but because that is equal to a burst, it then gets immediately set to the original address.  This might be achieved more directly using `DMA_CH_SRCDIR_FIXED_gc`.

I'm more confident in the change of the DMA CH1 trigger source to `DMA_CH_TRIGSRC_ADCA_CH2_gc` in `tiny_dma_set_mode_2`.  In the current firmware, it's instead set to `...ADCA_CH0_gc`, but the source address for DMA CH1 is ADCA_CH2.  It appears this discrepancy almost never or never matters because both ADC_CH0 and ADC_CH2 are sampling at the same frequency in this mode, but maybe it rears its head in some scenarios.